### PR TITLE
Enable and switch to python 3.7 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ pip install uarray
 ## Development
 
 ```bash
-conda create -n uarray python=3.6
+conda create -n uarray python=3.7
 conda activate uarray
 pip install -r requirements.dev.txt
 flit install --symlink

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ pool:
 steps:
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: '3.6'
+    versionSpec: '3.7'
     architecture: 'x64'
 
 - script: python -m pip install -r requirements.txt; flit install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,4 +18,5 @@ requires = [
 classifiers=[
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
 ]


### PR DESCRIPTION
After inspection of https://github.com/Quansight-Labs/uarray/pull/64 turns out that work was already done to move to python 3.7. This has been refactored out.

Will close issue https://github.com/Quansight-Labs/uarray/issues/68