### PR TITLE
Try in Native Python

### DIFF
--- a/notebooks/Native.ipynb
+++ b/notebooks/Native.ipynb
@@ -62,6 +62,42 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "a, b = np.arange(15), np.arange(15)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def outer_then_index_initial(a, b):\n",
+    "    return np.multiply.outer(a, b)[5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3.01 µs ± 65.2 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%timeit outer_then_index_initial(a, b)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def outer_then_index_np(a, b):\n",
     "    return to_numpy_array(outer_then_index(\n",
     "        AbstractArray.from_array(NumpyArray(a)),\n",
@@ -71,23 +107,117 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "array([ 0,  5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70])"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "413 µs ± 9.68 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)\n"
+     ]
     }
    ],
    "source": [
-    "outer_then_index_np(np.arange(10), np.arange(15))"
+    "%timeit outer_then_index_np(a, b)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def outer_then_index_np_default(a, b):\n",
+    "    return to_numpy_array(outer_then_index(\n",
+    "        NumpyArray(a),\n",
+    "        NumpyArray(b),\n",
+    "    ))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "350 µs ± 14.8 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%timeit outer_then_index_np_default(a, b)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a, b = np.arange(10000), np.arange(10000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "548 ms ± 3.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%timeit outer_then_index_initial(a, b)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "258 ms ± 3.79 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%timeit outer_then_index_np(a, b)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "777 ms ± 6.98 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%timeit outer_then_index_np_default(a, b)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/Native.ipynb
+++ b/notebooks/Native.ipynb
@@ -1,0 +1,114 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "from operator import mul\n",
+    "\n",
+    "from uarray.native.abstract import *\n",
+    "from uarray.native.moa import *\n",
+    "from uarray.native.helpers import *\n",
+    "from uarray.native.numpy import *"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def outer_then_index(a, b):\n",
+    "    idx = AbstractArray.from_naturals(AbstractNaturals.from_value(5))\n",
+    "    return index(idx, outer_product(a, b, mul, int))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = outer_then_index(iota(AbstractArray.from_value(10)), iota(AbstractArray.from_value(15)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 0,  5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70])"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "to_numpy_array(res)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def outer_then_index_np(a, b):\n",
+    "    return to_numpy_array(outer_then_index(\n",
+    "        AbstractArray.from_array(NumpyArray(a)),\n",
+    "        AbstractArray.from_array(NumpyArray(b)),\n",
+    "    ))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 0,  5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70])"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "outer_then_index_np(np.arange(10), np.arange(15))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/uarray/native/abstract.py
+++ b/uarray/native/abstract.py
@@ -1,0 +1,72 @@
+import typing
+import dataclasses
+
+
+from .typing import *
+from .helpers import *
+
+T = typing.TypeVar("T")
+
+
+__all__ = ["AbstractNaturals", "AbstractArray"]
+
+
+@dataclasses.dataclass
+class AbstractNaturals(Naturals):
+    length: int
+    getitem: typing.Callable[[int], int]
+
+    def __len__(self) -> int:
+        return self.length
+
+    def __getitem__(self, index: int) -> int:
+        return self.getitem(index)  # type: ignore
+
+    @classmethod
+    def empty(cls) -> "AbstractNaturals":
+        def getitem(x: int):
+            raise IndexError()
+
+        return cls(0, getitem)
+
+    @classmethod
+    def from_value(cls, x: int) -> "AbstractNaturals":
+        return cls(1, lambda _: x)
+
+    @classmethod
+    def from_array(cls, a: Array[int]) -> "AbstractNaturals":
+        assert is_vector(a)
+        return cls(u_shape(a)[0], lambda i: u_psi(a, cls.from_value(i)))
+
+    @classmethod
+    def from_sequence(cls, s: typing.Sequence[int]) -> "AbstractNaturals":
+        return cls(len(s), s.__getitem__)
+
+
+@dataclasses.dataclass
+class AbstractArray(Array[T]):
+    shape: Naturals
+    index_fn: Index[T]
+    mtype: typing.Type[T]
+
+    def __u_shape__(self) -> Naturals:
+        return self.shape
+
+    def __u_psi__(self, indices: Naturals) -> T:
+        return self.index_fn(indices)  # type: ignore
+
+    def __u_mtype__(self) -> typing.Type[T]:
+        return self.mtype
+
+    @classmethod
+    def from_value(cls, x: T, mtype: typing.Type[T] = None) -> "AbstractArray[T]":
+        return AbstractArray(tuple(), lambda _: x, mtype or type(x))
+
+    @classmethod
+    def from_naturals(cls, xs: Naturals) -> "AbstractArray[int]":
+        return AbstractArray((len(xs),), lambda idxs: xs[idxs[0]], int)
+
+    @classmethod
+    def from_array(cls, a: Array[T]) -> "AbstractArray[T]":
+        return AbstractArray(u_shape(a), a.__u_psi__, a.__u_mtype__())
+

--- a/uarray/native/helpers.py
+++ b/uarray/native/helpers.py
@@ -1,0 +1,26 @@
+import typing
+
+from .typing import *
+
+__all__ = ["u_shape", "u_psi", "u_mtype", "is_scalar", "is_vector"]
+T = typing.TypeVar("T")
+
+
+def u_shape(a: Array[T]) -> Naturals:
+    return a.__u_shape__()
+
+
+def u_psi(a: Array[T], indices: Naturals) -> T:
+    return a.__u_psi__(indices)
+
+
+def u_mtype(a: Array[T]) -> typing.Type[T]:
+    return a.__u_mtype__()
+
+
+def is_scalar(a: Array[T]):
+    return len(u_shape(a)) == 0
+
+
+def is_vector(a: Array[T]):
+    return len(u_shape(a)) == 1

--- a/uarray/native/moa.py
+++ b/uarray/native/moa.py
@@ -1,0 +1,101 @@
+import typing
+
+from .typing import *
+from .helpers import *
+from .abstract import *
+
+__all__ = [
+    "naturals_take",
+    "naturals_drop",
+    "naturals_concat",
+    "index",
+    "shape",
+    "dim",
+    "reduce",
+    "iota",
+    "outer_product",
+]
+
+T = typing.TypeVar("T")
+V = typing.TypeVar("V")
+R = typing.TypeVar("R")
+
+
+def naturals_take(n: Naturals, i: int) -> Naturals:
+    """
+    n[:i]
+    """
+    return AbstractNaturals(i, n.__getitem__)
+
+
+def naturals_drop(n: Naturals, i: int) -> Naturals:
+    """
+    n[i:]
+    """
+
+    def getitem(idx: int) -> int:
+        return n[idx + i]
+
+    return AbstractNaturals(len(n) - i, getitem)
+
+
+def naturals_concat(l: Naturals, r: Naturals) -> Naturals:
+    """
+    l + r
+    """
+
+    def getitem(i: int):
+        if i < len(l):
+            return l[i]
+        return r[i - len(l)]
+
+    return AbstractNaturals(len(l) + len(r), getitem)
+
+
+def index(idx: Array[int], a: Array[T]) -> Array[T]:
+    new_shape = naturals_drop(u_shape(a), u_shape(idx)[0])
+
+    idx_naturals = AbstractNaturals.from_array(idx)
+
+    def index_fn(inner_idx: Naturals) -> T:
+        total_idx = naturals_concat(idx_naturals, inner_idx)
+        return u_psi(a, total_idx)
+
+    return AbstractArray(new_shape, index_fn, u_mtype(a))
+
+
+def shape(a: Array[T]) -> Array[int]:
+    return AbstractArray.from_naturals(u_shape(a))
+
+
+def dim(a: Array[T]) -> Array[int]:
+    return AbstractArray.from_value(len(u_shape(a)), int)
+
+
+def reduce(
+    fn: typing.Callable[[Array[T], Array[T]], Array[T]], initial: Array[T], a: Array[T]
+) -> Array[T]:
+    value = initial
+    for i in range(u_shape(a)[0]):
+        value = fn(value, index(AbstractArray.from_value(i, int), a))
+    return value
+
+
+def iota(a: Array[int]) -> Array[int]:
+    assert is_scalar(a)
+
+    n = u_psi(a, AbstractNaturals.empty())
+    return AbstractArray(AbstractNaturals.from_value(n), lambda idxs: idxs[0], int)
+
+
+def outer_product(
+    l: Array[T], r: Array[V], op: typing.Callable[[T, V], R], mtype: typing.Type[R]
+) -> Array[R]:
+    first_dim = len(u_shape(l))
+
+    def index_fn(idx: Naturals) -> R:
+        l_idx = naturals_take(idx, first_dim)
+        r_idx = naturals_drop(idx, first_dim)
+        return op(u_psi(l, l_idx), u_psi(r, r_idx))
+
+    return AbstractArray(naturals_concat(u_shape(l), u_shape(r)), index_fn, mtype)

--- a/uarray/native/moa.py
+++ b/uarray/native/moa.py
@@ -1,4 +1,6 @@
 import typing
+import functools
+
 
 from .typing import *
 from .helpers import *
@@ -88,6 +90,7 @@ def iota(a: Array[int]) -> Array[int]:
     return AbstractArray(AbstractNaturals.from_value(n), lambda idxs: idxs[0], int)
 
 
+@functools.singledispatch
 def outer_product(
     l: Array[T], r: Array[V], op: typing.Callable[[T, V], R], mtype: typing.Type[R]
 ) -> Array[R]:

--- a/uarray/native/numpy.py
+++ b/uarray/native/numpy.py
@@ -49,3 +49,8 @@ def to_numpy_array(a: Array[T], nd: numpy.ndarray = None) -> numpy.ndarray:
 @to_numpy_array.register
 def _to_numpy_array_numpy(a: NumpyArray) -> numpy.ndarray:
     return a.a
+
+
+@outer_product.register
+def _outer_product_numpy(a: NumpyArray, b, op, mtype):
+    return NumpyArray(numpy.multiply.outer(a.a, b.a))

--- a/uarray/native/numpy.py
+++ b/uarray/native/numpy.py
@@ -1,0 +1,51 @@
+import functools
+import typing
+
+import numpy
+
+from .typing import *
+from .helpers import *
+from .abstract import *
+from .moa import *
+
+__all__ = ["NumpyArray", "to_numpy_array"]
+T = typing.TypeVar("T")
+
+
+def naturals_to_tuple(n: Naturals) -> typing.Tuple[int, ...]:
+    t: typing.Tuple[int, ...] = ()
+    for i in range(len(n)):
+        t += (n[i],)
+    return t
+
+
+class NumpyArray(Array[T]):
+    def __init__(self, a: numpy.ndarray):
+        self.a = a
+
+    def __u_shape__(self) -> Naturals:
+        return self.a.shape
+
+    def __u_psi__(self, indxs: Naturals) -> T:
+        return self.a[naturals_to_tuple(indxs)]
+
+    def __u_mtype__(self) -> typing.Type[T]:
+        return getattr(numpy, self.a.dtype.name)
+
+
+@functools.singledispatch
+def to_numpy_array(a: Array[T], nd: numpy.ndarray = None) -> numpy.ndarray:
+    if nd is None:
+        nd = numpy.empty(naturals_to_tuple(u_shape(a)), u_mtype(a))
+    if is_scalar(a):
+        nd[()] = u_psi(a, AbstractNaturals.empty())
+    else:
+        for i in range(u_shape(a)[0]):
+            idx = AbstractArray.from_naturals(AbstractNaturals.from_value(i))
+            to_numpy_array(index(idx, a), nd[i, ...])
+    return nd
+
+
+@to_numpy_array.register
+def _to_numpy_array_numpy(a: NumpyArray) -> numpy.ndarray:
+    return a.a

--- a/uarray/native/typing.py
+++ b/uarray/native/typing.py
@@ -1,0 +1,29 @@
+import typing
+import typing_extensions
+
+__all__ = ["Array", "Index", "Naturals"]
+
+T = typing.TypeVar("T")
+T_co = typing.TypeVar("T_co", covariant=True)
+
+
+class Naturals(typing_extensions.Protocol):
+    def __len__(self) -> int:
+        ...
+
+    def __getitem__(self, i: int) -> int:
+        ...
+
+
+class Array(typing_extensions.Protocol[T_co]):
+    def __u_shape__(self) -> Naturals:
+        ...
+
+    def __u_psi__(self, indices: Naturals) -> T_co:
+        ...
+
+    def __u_mtype__(self) -> typing.Type[T_co]:
+        ...
+
+
+Index = typing.Callable[[Naturals], T]


### PR DESCRIPTION
This adds an implementation using Python interfaces and python functions, instead of using MatchPy.

The array algorithms are type dispatching functions with a default implementation that works with generic arrays. 

The idea was that since we are writing in Python, let's not reinvent what it means to be a function and instead just write our functions imperatively in Python. So instead of writing things like `If(LessThan(x, Int(2)), ...)` we write `if x < 2: ...`. We restrict ourselves to a subset of Python types, `Array`s, `Naturals`' (see `./uarray/native/typing.py` for their definitions), and operations on integers. Then, given those types we build up MoA and NumPy semantics with functions on those types.


This approach is **a lot** easier to write and follow than the other of writing symbolic expressions, because we don't have to invent a new language/world to live in, we just use the Python one. 
"But how would we use this code to compile array algorithms to xxx (C, LLVM, Tensorflow)?" is the obvious question though. The reason I stayed away from doing things this way, was that then you have these opaque Python functions with control flow in them, and if you want to compile that to another backend then you have to somehow interpret those. Whereas, if you build everything up in MatchPy, you limit what is possible from the get-go, you don't get the freedom of the Python language. So yes, for this approach to be performant in any way, we would have to use/build something that could take these Python functions and re-interpret them as array expressions. Something a little like Numba, but also very different in scope.

From a high level, to compile/optimize these types of expressions would require at least three things:

1. Abstraction removal/function inlining: All array functions and indexing functions should be inlined, so that you have just have one large piece of code without any dependence any python classes/functions besides the array operations and number math.
2. Constant folding/partial evaluation: Often, there are multiple code paths depending on the dimensionality of the inputs. These should be evaluated at compile time, when possible, so we need to be able to evaluate things at compile time that can be known and replace control flow that we can also know about it (i.e. if we have an `if` statement and know it's condition, then we can replace it)
3. All of that is fine, and wil help to produce some cleaner Python code, but then at some point we actually need to convert that to whatever compilation target we care about. For example, any unknown control flow (I am thinking mostly here of `if`) need to be compiled to the target language, like LLVM. 

Pros of this approach:
* Separates Python implementations of array algorithms from how to compile them
* Integrates nicely with proposed array protocol
* Allows us to write array algorithms in native python

Cons of this approach:
* Need to implement python bytecode or AST parser and transformer. This is more work than starting in the abstract array indexing form we care about.
  * This also ties us closer to the Python implementation. So it might be harder to upgrade Python versions.
* It's not as easy to constrain the language we are working in. Even if we don't support all of Python, users can still try to use features we don't support and it's hard to prevent that. Yes, we can raise an error, but it's much easier to prevent expressions a MatchPy world, where we get to build what is allowed. 

My current recommendation:
* I have found this useful to implement and I think it has some value at least in learning what primitives we need from this type of system
* I think work should continue on the matchpy approach, with one eventual outcome being we can translate from this new Python first approach into a symbolic approach.