### PR TITLE
Remove canonicalization.

### DIFF
--- a/uarray/backend.py
+++ b/uarray/backend.py
@@ -96,7 +96,7 @@ def generate_multimethod(
 
     @functools.wraps(argument_extractor)
     def inner(*args, **kwargs):
-        args, kwargs = _canonicalize(argument_extractor, args, kwargs)
+        # args, kwargs = _canonicalize(argument_extractor, args, kwargs)
         dispatchable_args = argument_extractor(*args, **kwargs)
         errors = []
 


### PR DESCRIPTION
Remove canonicalization (for now). Will come up with alternative strategies later. :slightly_smiling_face: 

Benchmarks: 30.7 microseconds (old) versus 2.06 microseconds (new).