### PR TITLE
Improvements to _uarray.Function

### DIFF
--- a/uarray/__init__.py
+++ b/uarray/__init__.py
@@ -110,6 +110,7 @@ possible.
 """
 
 from ._backend import *
+from ._backend import _Function
 from ._version import get_versions  # type: ignore
 
 __version__ = get_versions()["version"]

--- a/uarray/_backend.py
+++ b/uarray/_backend.py
@@ -11,9 +11,7 @@ from typing import (
     List,
 )
 import inspect
-from contextvars import ContextVar
 import functools
-import contextlib
 from . import _uarray  # type: ignore
 
 ArgumentExtractorType = Callable[..., Tuple["Dispatchable", ...]]

--- a/uarray/_backend.py
+++ b/uarray/_backend.py
@@ -17,7 +17,12 @@ from . import _uarray  # type: ignore
 ArgumentExtractorType = Callable[..., Tuple["Dispatchable", ...]]
 ArgumentReplacerType = Callable[[Tuple, Dict, Tuple], Tuple[Tuple, Dict]]
 
-from ._uarray import BackendNotImplementedError
+from ._uarray import (
+    BackendNotImplementedError,
+    _Function,
+    _SkipBackendContext,
+    _SetBackendContext,
+)
 
 import atexit
 
@@ -107,7 +112,7 @@ def generate_multimethod(
         See the module documentation for how to override the method by creating backends.
     """
     kw_defaults, arg_defaults, opts = get_defaults(argument_extractor)
-    ua_func = _uarray.Function(
+    ua_func = _Function(
         argument_extractor,
         argument_replacer,
         domain,
@@ -134,7 +139,7 @@ def set_backend(backend, *args, **kwargs):
     BackendOptions: The backend plus options.
     skip_backend: A context manager that allows skipping of backends.
     """
-    return _uarray.SetBackendContext(backend, *args, **kwargs)
+    return _SetBackendContext(backend, *args, **kwargs)
 
 
 def skip_backend(backend):
@@ -152,7 +157,7 @@ def skip_backend(backend):
     --------
     set_backend: A context manager that allows setting of backends.
     """
-    return _uarray.SkipBackendContext(backend)
+    return _SkipBackendContext(backend)
 
 
 def get_defaults(f):

--- a/uarray/_uarray_dispatch.cxx
+++ b/uarray/_uarray_dispatch.cxx
@@ -918,7 +918,7 @@ PyMethodDef Function_methods[] =
 
 PyTypeObject FunctionType = {
   PyVarObject_HEAD_INIT(NULL, 0)
-  "uarray._uarray.Function",       /* tp_name */
+  "uarray._Function",              /* tp_name */
   sizeof(Function),                /* tp_basicsize */
   0,                               /* tp_itemsize */
   (destructor)Function::dealloc,   /* tp_dealloc */
@@ -967,7 +967,7 @@ PyMethodDef SetBackendContext_Methods[] = {
 
 PyTypeObject SetBackendContextType = {
   PyVarObject_HEAD_INIT(NULL, 0)
-  "uarray._uarray.SetBackendContext",      /* tp_name */
+  "uarray._SetBackendContext",             /* tp_name */
   sizeof(SetBackendContext),               /* tp_basicsize */
   0,                                       /* tp_itemsize */
   (destructor)SetBackendContext::dealloc,  /* tp_dealloc */
@@ -1015,7 +1015,7 @@ PyMethodDef SkipBackendContext_Methods[] = {
 
 PyTypeObject SkipBackendContextType = {
   PyVarObject_HEAD_INIT(NULL, 0)
-  "uarray._uarray.SkipBackendContext",      /* tp_name */
+  "uarray._SkipBackendContext",             /* tp_name */
   sizeof(SkipBackendContext),               /* tp_basicsize */
   0,                                        /* tp_itemsize */
   (destructor)SkipBackendContext::dealloc,  /* tp_dealloc */
@@ -1099,18 +1099,18 @@ PyInit__uarray(void)
   if (PyType_Ready(&FunctionType) < 0)
     return nullptr;
   Py_INCREF(&FunctionType);
-  PyModule_AddObject(m, "Function", (PyObject *)&FunctionType);
+  PyModule_AddObject(m, "_Function", (PyObject *)&FunctionType);
 
   if (PyType_Ready(&SetBackendContextType) < 0)
     return nullptr;
   Py_INCREF(&SetBackendContextType);
-  PyModule_AddObject(m, "SetBackendContext", (PyObject*)&SetBackendContextType);
+  PyModule_AddObject(m, "_SetBackendContext", (PyObject*)&SetBackendContextType);
 
   if (PyType_Ready(&SkipBackendContextType) < 0)
     return nullptr;
   Py_INCREF(&SkipBackendContextType);
   PyModule_AddObject(
-    m, "SkipBackendContext", (PyObject*)&SkipBackendContextType);
+    m, "_SkipBackendContext", (PyObject*)&SkipBackendContextType);
 
   BackendNotImplementedError = py_ref::steal(
     PyErr_NewExceptionWithDoc(

--- a/uarray/_uarray_dispatch.cxx
+++ b/uarray/_uarray_dispatch.cxx
@@ -572,6 +572,13 @@ struct Function
 
       return 0;
     }
+
+  static PyObject * repr(Function * self);
+  static PyObject * descr_get(PyObject * self, PyObject * obj, PyObject * type);
+  static int traverse(Function * self, visitproc visit, void * arg);
+  static int clear(Function * self);
+  static PyObject * getstate__(Function * self, PyObject * args);
+  static PyObject * setstate__(Function * self, PyObject * args);
 };
 
 
@@ -786,7 +793,7 @@ PyObject * Function::call(PyObject * args_, PyObject * kwargs_)
 }
 
 
-PyObject * Function_repr(Function * self)
+PyObject * Function::repr(Function * self)
 {
   if (self->dict_)
     if (auto name = PyDict_GetItemString(self->dict_, "__name__"))
@@ -797,7 +804,7 @@ PyObject * Function_repr(Function * self)
 
 
 /** Implements the descriptor protocol to allow binding to class instances */
-PyObject * Function_descr_get(PyObject * self, PyObject * obj, PyObject * type)
+PyObject * Function::descr_get(PyObject * self, PyObject * obj, PyObject * type)
 {
   if (!obj)
   {
@@ -810,7 +817,7 @@ PyObject * Function_descr_get(PyObject * self, PyObject * obj, PyObject * type)
 
 
 /** Make members visible to the garbage collector */
-int Function_traverse(Function * self, visitproc visit, void * arg)
+int Function::traverse(Function * self, visitproc visit, void * arg)
 {
   Py_VISIT(self->extractor_);
   Py_VISIT(self->replacer_);
@@ -823,7 +830,7 @@ int Function_traverse(Function * self, visitproc visit, void * arg)
 
 
 /** Break reference cycles when being GCed */
-int Function_clear(Function * self)
+int Function::clear(Function * self)
 {
   self->extractor_.reset();
   self->replacer_.reset();
@@ -836,7 +843,7 @@ int Function_clear(Function * self)
 
 
 /** Support for pickle.dump */
-PyObject * Function___getstate__(Function * self, PyObject * /*args*/)
+PyObject * Function::getstate__(Function * self, PyObject * /*args*/)
 {
   auto domain = py_ref::steal(
     PyUnicode_FromStringAndSize(self->domain_key_.data(),
@@ -857,7 +864,7 @@ PyObject * Function___getstate__(Function * self, PyObject * /*args*/)
 
 
 /** Support for pickle.load */
-PyObject * Function___setstate__(Function * self, PyObject * args)
+PyObject * Function::setstate__(Function * self, PyObject * args)
 {
   PyObject * state_tuple = nullptr;
   if (!PyArg_ParseTuple(args, "O!", &PyTuple_Type, &state_tuple))
@@ -904,51 +911,51 @@ PyGetSetDef Function_getset[] =
 
 PyMethodDef Function_methods[] =
 {
-  {"__getstate__", (binaryfunc)Function___getstate__, METH_NOARGS, nullptr},
-  {"__setstate__", (binaryfunc)Function___setstate__, METH_VARARGS, nullptr},
+  {"__getstate__", (binaryfunc)Function::getstate__, METH_NOARGS, nullptr},
+  {"__setstate__", (binaryfunc)Function::setstate__, METH_VARARGS, nullptr},
   {NULL} /* Sentinel */
 };
 
 PyTypeObject FunctionType = {
   PyVarObject_HEAD_INIT(NULL, 0)
-  "uarray._uarray.Function",      /* tp_name */
-  sizeof(Function),               /* tp_basicsize */
-  0,                              /* tp_itemsize */
-  (destructor)Function::dealloc,  /* tp_dealloc */
-  0,                              /* tp_print */
-  0,                              /* tp_getattr */
-  0,                              /* tp_setattr */
-  0,                              /* tp_reserved */
-  (reprfunc)Function_repr,        /* tp_repr */
-  0,                              /* tp_as_number */
-  0,                              /* tp_as_sequence */
-  0,                              /* tp_as_mapping */
-  0,                              /* tp_hash  */
-  (ternaryfunc)Function_call,     /* tp_call */
-  0,                              /* tp_str */
-  PyObject_GenericGetAttr,        /* tp_getattro */
-  PyObject_GenericSetAttr,        /* tp_setattro */
-  0,                              /* tp_as_buffer */
+  "uarray._uarray.Function",       /* tp_name */
+  sizeof(Function),                /* tp_basicsize */
+  0,                               /* tp_itemsize */
+  (destructor)Function::dealloc,   /* tp_dealloc */
+  0,                               /* tp_print */
+  0,                               /* tp_getattr */
+  0,                               /* tp_setattr */
+  0,                               /* tp_reserved */
+  (reprfunc)Function::repr,        /* tp_repr */
+  0,                               /* tp_as_number */
+  0,                               /* tp_as_sequence */
+  0,                               /* tp_as_mapping */
+  0,                               /* tp_hash  */
+  (ternaryfunc)Function_call,      /* tp_call */
+  0,                               /* tp_str */
+  PyObject_GenericGetAttr,         /* tp_getattro */
+  PyObject_GenericSetAttr,         /* tp_setattro */
+  0,                               /* tp_as_buffer */
   (Py_TPFLAGS_DEFAULT
-   | Py_TPFLAGS_HAVE_GC),         /* tp_flags */
-  0,                              /* tp_doc */
-  (traverseproc)Function_traverse,/* tp_traverse */
-  (inquiry)Function_clear,        /* tp_clear */
-  0,                              /* tp_richcompare */
-  0,                              /* tp_weaklistoffset */
-  0,                              /* tp_iter */
-  0,                              /* tp_iternext */
-  Function_methods,               /* tp_methods */
-  0,                              /* tp_members */
-  Function_getset,                /* tp_getset */
-  0,                              /* tp_base */
-  0,                              /* tp_dict */
-  Function_descr_get,             /* tp_descr_get */
-  0,                              /* tp_descr_set */
-  offsetof(Function, dict_),      /* tp_dictoffset */
-  (initproc)Function::init,       /* tp_init */
-  0,                              /* tp_alloc */
-  Function::new_,                 /* tp_new */
+   | Py_TPFLAGS_HAVE_GC),          /* tp_flags */
+  0,                               /* tp_doc */
+  (traverseproc)Function::traverse,/* tp_traverse */
+  (inquiry)Function::clear,        /* tp_clear */
+  0,                               /* tp_richcompare */
+  0,                               /* tp_weaklistoffset */
+  0,                               /* tp_iter */
+  0,                               /* tp_iternext */
+  Function_methods,                /* tp_methods */
+  0,                               /* tp_members */
+  Function_getset,                 /* tp_getset */
+  0,                               /* tp_base */
+  0,                               /* tp_dict */
+  Function::descr_get,             /* tp_descr_get */
+  0,                               /* tp_descr_set */
+  offsetof(Function, dict_),       /* tp_dictoffset */
+  (initproc)Function::init,        /* tp_init */
+  0,                               /* tp_alloc */
+  Function::new_,                  /* tp_new */
 };
 
 

--- a/uarray/_uarray_dispatch.cxx
+++ b/uarray/_uarray_dispatch.cxx
@@ -822,15 +822,83 @@ int Function_traverse(Function * self, visitproc visit, void * arg)
 }
 
 
+/** Support for pickle.dump */
+PyObject * Function___getstate__(Function * self, PyObject * /*args*/)
+{
+  auto domain = py_ref::steal(
+    PyUnicode_FromStringAndSize(self->domain_key_.data(),
+                                self->domain_key_.size()));
+  if (!domain)
+    return nullptr;
+
+  auto res = py_make_tuple(self->extractor_,
+                           self->replacer_,
+                           domain,
+                           self->def_args_,
+                           self->def_kwargs_,
+                           self->def_impl_,
+                           self->dict_ ? self->dict_ : Py_None);
+
+  return res.release();
+}
+
+
+/** Support for pickle.load */
+PyObject * Function___setstate__(Function * self, PyObject * args)
+{
+  PyObject * state_tuple = nullptr;
+  if (!PyArg_ParseTuple(args, "O!", &PyTuple_Type, &state_tuple))
+    return nullptr;
+
+  if (PyTuple_GET_SIZE(state_tuple) != 7)
+  {
+    PyErr_SetString(PyExc_ValueError, "State tuple must have 7 entries");
+    return nullptr;
+  }
+
+  auto init_args = py_ref::steal(PyTuple_GetSlice(state_tuple, 0, 6));
+  if (!init_args)
+    return nullptr;
+
+  if (Function::init(self, init_args, nullptr) < 0)
+    return nullptr;
+
+  auto dict = py_ref::ref(PyTuple_GET_ITEM(state_tuple, 6));
+  if (dict == Py_None)
+  {
+    self->dict_.reset();
+  }
+  else
+  {
+    if (!PyDict_CheckExact(dict))
+    {
+      PyErr_SetString(PyExc_TypeError, "State __dict__ is not a dict object");
+      return nullptr;
+    }
+
+    self->dict_ = std::move(dict);
+  }
+
+  Py_RETURN_NONE;
+}
+
+
 PyGetSetDef Function_getset[] =
 {
   {"__dict__", PyObject_GenericGetDict, PyObject_GenericSetDict},
   {NULL} /* Sentinel */
 };
 
+PyMethodDef Function_methods[] =
+{
+  {"__getstate__", (binaryfunc)Function___getstate__, METH_NOARGS, nullptr},
+  {"__setstate__", (binaryfunc)Function___setstate__, METH_VARARGS, nullptr},
+  {NULL} /* Sentinel */
+};
+
 PyTypeObject FunctionType = {
   PyVarObject_HEAD_INIT(NULL, 0)
-  "_uarray.Function",             /* tp_name */
+  "uarray._uarray.Function",      /* tp_name */
   sizeof(Function),               /* tp_basicsize */
   0,                              /* tp_itemsize */
   (destructor)Function::dealloc,  /* tp_dealloc */
@@ -857,7 +925,7 @@ PyTypeObject FunctionType = {
   0,                              /* tp_weaklistoffset */
   0,                              /* tp_iter */
   0,                              /* tp_iternext */
-  0,                              /* tp_methods */
+  Function_methods,               /* tp_methods */
   0,                              /* tp_members */
   Function_getset,                /* tp_getset */
   0,                              /* tp_base */
@@ -879,7 +947,7 @@ PyMethodDef SetBackendContext_Methods[] = {
 
 PyTypeObject SetBackendContextType = {
   PyVarObject_HEAD_INIT(NULL, 0)
-  "_uarray.SetBackendContext",             /* tp_name */
+  "uarray._uarray.SetBackendContext",      /* tp_name */
   sizeof(SetBackendContext),               /* tp_basicsize */
   0,                                       /* tp_itemsize */
   (destructor)SetBackendContext::dealloc,  /* tp_dealloc */
@@ -927,7 +995,7 @@ PyMethodDef SkipBackendContext_Methods[] = {
 
 PyTypeObject SkipBackendContextType = {
   PyVarObject_HEAD_INIT(NULL, 0)
-  "_uarray.SkipBackendContext",             /* tp_name */
+  "uarray._uarray.SkipBackendContext",      /* tp_name */
   sizeof(SkipBackendContext),               /* tp_basicsize */
   0,                                        /* tp_itemsize */
   (destructor)SkipBackendContext::dealloc,  /* tp_dealloc */

--- a/uarray/_uarray_dispatch.cxx
+++ b/uarray/_uarray_dispatch.cxx
@@ -822,6 +822,19 @@ int Function_traverse(Function * self, visitproc visit, void * arg)
 }
 
 
+/** Break reference cycles when being GCed */
+int Function_clear(Function * self)
+{
+  self->extractor_.reset();
+  self->replacer_.reset();
+  self->def_args_.reset();
+  self->def_kwargs_.reset();
+  self->def_impl_.reset();
+  self->dict_.reset();
+  return 0;
+}
+
+
 /** Support for pickle.dump */
 PyObject * Function___getstate__(Function * self, PyObject * /*args*/)
 {
@@ -920,7 +933,7 @@ PyTypeObject FunctionType = {
    | Py_TPFLAGS_HAVE_GC),         /* tp_flags */
   0,                              /* tp_doc */
   (traverseproc)Function_traverse,/* tp_traverse */
-  0,                              /* tp_clear */
+  (inquiry)Function_clear,        /* tp_clear */
   0,                              /* tp_richcompare */
   0,                              /* tp_weaklistoffset */
   0,                              /* tp_iter */

--- a/uarray/tests/test_uarray.py
+++ b/uarray/tests/test_uarray.py
@@ -1,4 +1,5 @@
 import uarray as ua
+import pickle
 
 
 class Backend:
@@ -39,8 +40,6 @@ def _replacer(args, kwargs, dispatchables):
 
 
 def test_pickle_support():
-    import pickle
-
     mm = ua.generate_multimethod(_extractor, _replacer, "ua_tests")
     mm.attr = "hello"
 
@@ -51,3 +50,12 @@ def test_pickle_support():
 
     assert mm_unpickled.attr == "hello"
     assert mm_unpickled.__getstate__() == state
+
+
+def test_pickle_no_dict():
+    # Special case where Function->dict_ is nullptr
+    mm = ua._Function(_extractor, _replacer, "ua_tests", (), {}, None)
+    assert mm.__getstate__()[6] is None  # Holds __dict__
+
+    mm_unpickled = pickle.loads(pickle.dumps(mm))
+    assert mm_unpickled.__dict__ == mm.__dict__

--- a/uarray/tests/test_uarray.py
+++ b/uarray/tests/test_uarray.py
@@ -28,3 +28,26 @@ def test_nestedbackend():
     be_inner.__ua_function__ = be2_ua_func
     with ua.set_backend(be_outer), ua.set_backend(be_inner):
         assert mm2() is obj
+
+
+def _extractor():
+    return ()
+
+
+def _replacer(args, kwargs, dispatchables):
+    return (args, kwargs)
+
+
+def test_pickle_support():
+    import pickle
+
+    mm = ua.generate_multimethod(_extractor, _replacer, "ua_tests")
+    mm.attr = "hello"
+
+    state = mm.__getstate__()
+
+    s = pickle.dumps(mm)
+    mm_unpickled = pickle.loads(s)
+
+    assert mm_unpickled.attr == "hello"
+    assert mm_unpickled.__getstate__() == state


### PR DESCRIPTION
This PR adds to `Function`:
- `__getstate__` and `__setstate__`, allowing multimethods to be pickled.
- `tp_clear` which is used by the GC when handling cyclic references.