### PR TITLE
Remove f-strings to be Py35 compatible

### DIFF
--- a/uarray/_backend.py
+++ b/uarray/_backend.py
@@ -287,8 +287,8 @@ class Dispatchable:
         return (self.type, self.value)[index]
 
     def __str__(self):
-        return (
-            f"<{type(self).__name__}: type={repr(self.type)}, value={repr(self.value)}>"
+        return "<{0}: type={1!r}, value={2!r}>".format(
+            type(self).__name__, self.type, self.value
         )
 
     __repr__ = __str__

--- a/unumpy/multimethods.py
+++ b/unumpy/multimethods.py
@@ -56,7 +56,7 @@ class ufunc:
         self.nin, self.nout = nin, nout
 
     def __str__(self):
-        return f"<ufunc '{self.name}'>"
+        return "<ufunc '{}'>".format(self.name)
 
     @property  # type: ignore
     @create_numpy(_self_argreplacer)


### PR DESCRIPTION
As you pointed out in https://github.com/scipy/scipy/pull/10383#issuecomment-509796258, f-strings cannot be used with older versions of python.

It would also be good to add a new CI check for python 3.5. I'm not familiar with azure though.