### PR TITLE
Potentially fix read the docs builds

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
 include versioneer.py
 recursive-include uarray *.py
 recursive-include unumpy *.py
-recursive-include ulinalg *.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,22 @@
 import os
 import sys
 
+
+# Mock Extension modules
+try:
+    import uarray._uarray
+except ImportError:
+    from unittest.mock import MagicMock
+
+    class Mock(MagicMock):
+        @classmethod
+        def __getattr__(cls, name):
+            return MagicMock()
+
+    MOCK_MODULES = ["uarray._uarray"]
+    sys.modules.update((mod, Mock()) for mod in MOCK_MODULES)
+
+
 # sys.path.insert(0, os.path.abspath('.'))
 from typing import List, Dict
 


### PR DESCRIPTION
Read the docs does not seem to allow extension modules
https://docs.readthedocs.io/en/stable/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules