### PR TITLE
Define __all__ for uarray

### DIFF
--- a/uarray/__init__.py
+++ b/uarray/__init__.py
@@ -110,7 +110,6 @@ possible.
 """
 
 from ._backend import *
-from ._backend import _Function
 from ._version import get_versions  # type: ignore
 
 __version__ = get_versions()["version"]

--- a/uarray/_backend.py
+++ b/uarray/_backend.py
@@ -27,6 +27,22 @@ from ._uarray import (
     _SetBackendContext,
 )
 
+__all__ = [
+    "set_backend",
+    "set_global_backend",
+    "skip_backend",
+    "register_backend",
+    "clear_backends",
+    "create_multimethod",
+    "generate_multimethod",
+    "_Function",
+    "BackendNotImplementedError",
+    "Dispatchable",
+    "wrap_single_convertor",
+    "all_of_type",
+    "mark_as",
+]
+
 
 def unpickle_function(mod_name, qname):
     import importlib
@@ -267,7 +283,7 @@ def clear_backends(domain, registered=True, globals=False):
         We caution library authors against using this function in
         their code. We do *not* support this use-case. This function
         is meant to be used only by users themselves.
-    
+
     .. warning::
         Do NOT use this method inside a multimethod call, or the
         program is likely to crash.
@@ -281,7 +297,7 @@ def clear_backends(domain, registered=True, globals=False):
         Whether or not to clear registered backends. See :obj:`register_backend`.
     globals : bool
         Whether or not to clear global backends. See :obj:`set_global_backend`.
-    
+
     See Also
     --------
     register_backend : Register a backend globally.


### PR DESCRIPTION
Since `__init__.py` imports `*`, it exports things like `Callable` or `atexit`.