### PR TITLE
 Fix write-strings warning on python < 3.7 

### DIFF
--- a/.conda/environment3.7.yml
+++ b/.conda/environment3.7.yml
@@ -3,7 +3,7 @@ channels:
   - defaults
   - conda-forge
 dependencies:
-  - python=3.7
+  - python=3.7.3
   - pip
   - sphinx
   - sphinx_rtd_theme

--- a/uarray/_uarray_dispatch.cxx
+++ b/uarray/_uarray_dispatch.cxx
@@ -889,9 +889,11 @@ int Function::clear(Function * self)
 }
 
 
+// getset takes mutable char * in python < 3.7
+static char dict__[] = "__dict__";
 PyGetSetDef Function_getset[] =
 {
-  {"__dict__", PyObject_GenericGetDict, PyObject_GenericSetDict},
+  {dict__, PyObject_GenericGetDict, PyObject_GenericSetDict},
   {NULL} /* Sentinel */
 };
 

--- a/uarray/_uarray_dispatch.cxx
+++ b/uarray/_uarray_dispatch.cxx
@@ -219,7 +219,7 @@ PyObject * set_global_backend(PyObject * /* self */, PyObject * args)
 PyObject * register_backend(PyObject * /* self */, PyObject * args)
 {
   PyObject * backend;
-  if (!PyArg_ParseTuple(args, "O", 
+  if (!PyArg_ParseTuple(args, "O",
     &backend))
     return nullptr;
 
@@ -242,7 +242,7 @@ void clear_single(const std::string& domain, bool registered, bool global)
       global_domain_map.erase(domain_globals);
       return;
     }
-  
+
   if (registered)
   {
     domain_globals->second.registered.clear();
@@ -258,7 +258,7 @@ PyObject * clear_backends(PyObject * /* self */, PyObject * args)
 {
   PyObject* domain = nullptr;
   int registered = true, global = false;
-  if (!PyArg_ParseTuple(args, "O|pp", 
+  if (!PyArg_ParseTuple(args, "O|pp",
     &domain, &registered, &global))
     return nullptr;
 


### PR DESCRIPTION
Fixes a compiler warning specific to python < 3.7:
>`uarray/_uarray_dispatch.cxx:896:1: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]`