### PR TITLE
Revert workaround for packaging issue.

### DIFF
--- a/.conda/environment3.7.yml
+++ b/.conda/environment3.7.yml
@@ -3,7 +3,7 @@ channels:
   - defaults
   - conda-forge
 dependencies:
-  - python=3.7.3
+  - python
   - pip
   - sphinx
   - sphinx_rtd_theme


### PR DESCRIPTION
Reverts a workaround added in #195 for ContinuumIO/anaconda-issues#11195.