### PR TITLE
Catch BackendNotImplementedError raised from __ua_function__

### DIFF
--- a/uarray/_uarray_dispatch.cxx
+++ b/uarray/_uarray_dispatch.cxx
@@ -747,6 +747,49 @@ PyObject * Function_call(
   return self->call(args, kwargs);
 }
 
+class py_errinf
+{
+  py_ref type_, value_, traceback_;
+
+public:
+  static py_errinf fetch()
+  {
+    PyObject * type, * value, * traceback;
+    PyErr_Fetch(&type, &value, &traceback);
+    py_errinf err;
+    err.set(type, value, traceback);
+    return err;
+  }
+
+  py_ref get_exception()
+  {
+    normalize();
+    return value_;
+  }
+
+private:
+
+  void set(PyObject * type, PyObject * value, PyObject * traceback)
+  {
+    type_ = py_ref::steal(type);
+    value_ = py_ref::steal(value);
+    traceback_ = py_ref::steal(traceback);
+  }
+
+  void normalize()
+  {
+    auto type = type_.release();
+    auto value = value_.release();
+    auto traceback = value_.release();
+    PyErr_NormalizeException(&type, &value, &traceback);
+    if (traceback)
+    {
+      PyException_SetTraceback(value, traceback);
+    }
+    set(type, value, traceback);
+  }
+};
+
 
 PyObject * Function::call(PyObject * args_, PyObject * kwargs_)
 {
@@ -754,6 +797,8 @@ PyObject * Function::call(PyObject * args_, PyObject * kwargs_)
   auto kwargs = canonicalize_kwargs(kwargs_);
 
   py_ref result;
+  std::vector<py_errinf> errors;
+
 
   auto ret = for_each_backend(
     domain_key_,
@@ -778,6 +823,13 @@ PyObject * Function::call(PyObject * args_, PyObject * kwargs_)
 
         result = py_ref::steal(
           PyObject_Call(ua_function, ua_func_args, nullptr));
+
+        // raise BackendNotImplemeted is equivalent to return NotImplemented
+        if (!result && PyErr_ExceptionMatches(BackendNotImplementedError))
+        {
+          errors.push_back(py_errinf::fetch());
+          result = py_ref::ref(Py_NotImplemented);
+        }
 
         // Try the default with this backend
         if (result == Py_NotImplemented && def_impl_ != Py_None)
@@ -807,7 +859,7 @@ PyObject * Function::call(PyObject * args_, PyObject * kwargs_)
 
           if (PyErr_Occurred() && PyErr_ExceptionMatches(BackendNotImplementedError))
           {
-            PyErr_Clear();  // Suppress exception
+            errors.push_back(py_errinf::fetch());
             result = py_ref::ref(Py_NotImplemented);
           }
 
@@ -828,15 +880,35 @@ PyObject * Function::call(PyObject * args_, PyObject * kwargs_)
   if (ret != LoopReturn::Continue)
     return result.release();
 
-  if (def_impl_ == Py_None)
+  if (def_impl_ != Py_None)
   {
-    PyErr_SetString(
-      BackendNotImplementedError,
-      "No selected backends had an implementation for this function.");
-    return nullptr;
+    result = py_ref::steal(PyObject_Call(def_impl_, args, kwargs));
+    if (!result)
+    {
+      if (!PyErr_ExceptionMatches(BackendNotImplementedError))
+        return nullptr;
+
+      errors.push_back(py_errinf::fetch());
+      result = py_ref::ref(Py_NotImplemented);
+    }
+    else if (result != Py_NotImplemented)
+      return result.release();
   }
 
-  return PyObject_Call(def_impl_, args, kwargs);
+
+  // All backends and defaults failed, construct the exception
+  auto exception_tuple = py_ref::steal(PyTuple_New(errors.size() + 1));
+  PyTuple_SET_ITEM(
+    exception_tuple.get(), 0,
+    PyUnicode_FromString(
+      "No selected backends had an implementation for this function."));
+  for (Py_ssize_t i = 0; i < errors.size(); ++i)
+  {
+    PyTuple_SET_ITEM(
+      exception_tuple.get(), i+1, errors[i].get_exception().release());
+  }
+  PyErr_SetObject(BackendNotImplementedError, exception_tuple.get());
+  return nullptr;
 }
 
 

--- a/uarray/tests/test_uarray.py
+++ b/uarray/tests/test_uarray.py
@@ -27,15 +27,12 @@ def test_nestedbackend():
     be_outer = Backend()
     be_outer.__ua_function__ = lambda f, a, kw: obj
 
-    mm1 = ua.generate_multimethod(lambda: (), lambda a, kw, d: (a, kw), "ua_tests")
+    mm1 = create_nullary_mm()
 
     def default(*a, **kw):
         return mm1(*a, **kw)
 
-    mm2 = ua.generate_multimethod(
-        lambda: (), lambda a, kw, d: (a, kw), "ua_tests", default=default
-    )
-
+    mm2 = create_nullary_mm(default=default)
     be_inner = Backend()
 
     def be2_ua_func(f, a, kw):
@@ -66,7 +63,7 @@ def test_registration(cleanup_backends):
     obj = object()
     be = Backend()
     be.__ua_function__ = lambda f, a, kw: obj
-    mm = ua.generate_multimethod(lambda: (), lambda a, kw, d: (a, kw), "ua_tests")
+    mm = create_nullary_mm()
 
     ua.register_backend(be)
     assert mm() is obj
@@ -76,7 +73,7 @@ def test_global(cleanup_backends):
     obj = object()
     be = Backend()
     be.__ua_function__ = lambda f, a, kw: obj
-    mm = ua.generate_multimethod(lambda: (), lambda a, kw, d: (a, kw), "ua_tests")
+    mm = create_nullary_mm()
 
     ua.set_global_backend(be)
     assert mm() is obj
@@ -90,7 +87,7 @@ def ctx_before_global(cleanup_backends):
 
     be2 = Backend()
     be2.__ua_function__ = lambda f, a, kw: obj2
-    mm = ua.generate_multimethod(lambda: (), lambda a, kw, d: (a, kw), "ua_tests")
+    mm = create_nullary_mm()
 
     ua.set_global_backend(be)
 
@@ -106,7 +103,7 @@ def test_global_before_registered(cleanup_backends):
 
     be2 = Backend()
     be2.__ua_function__ = lambda f, a, kw: obj2
-    mm = ua.generate_multimethod(lambda: (), lambda a, kw, d: (a, kw), "ua_tests")
+    mm = create_nullary_mm()
 
     ua.set_global_backend(be)
     ua.register_backend(be2)
@@ -120,7 +117,7 @@ def test_global_only(cleanup_backends):
 
     be2 = Backend()
     be2.__ua_function__ = lambda f, a, kw: obj
-    mm = ua.generate_multimethod(lambda: (), lambda a, kw, d: (a, kw), "ua_tests")
+    mm = create_nullary_mm()
 
     ua.set_global_backend(be, only=True)
     ua.register_backend(be2)
@@ -137,7 +134,7 @@ def test_clear_backends(cleanup_backends):
 
     be2 = Backend()
     be2.__ua_function__ = lambda f, a, kw: obj2
-    mm = ua.generate_multimethod(lambda: (), lambda a, kw, d: (a, kw), "ua_tests")
+    mm = create_nullary_mm()
 
     ua.set_global_backend(be)
     ua.register_backend(be2)


### PR DESCRIPTION
Closes #197

This catches any `BackendNotImplementedError`s raised by `__ua_function__` and stores them in a list until the end of the function call process. At which point if no backends have been called, the exception objects are made into a tuple before raising the final exception object.

This gives errors such as 
> `BackendNotImplementedError: ('No selected backends had an implementation for this function.', BackendNotImplementedError('Foo'))`

Questions:
* Should the nested-exceptions be associated with their backend? e.g. the tuple could contain tuples of `(backend, exception)`.
* Should the exception list include backends that returned `NotImplemeted`?

