### PR TITLE
Add support for pypy3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,11 @@ jobs:
     vmImage: 'ubuntu-16.04'
   steps:
     - template: ci/azure-run-clang-format.yml
+- job: pypy3
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+    - template: ci/azure-pypy3.yml
 
 
 trigger:

--- a/ci/azure-pypy3.yml
+++ b/ci/azure-pypy3.yml
@@ -1,0 +1,23 @@
+steps:
+- checkout: self
+  path: uarray
+- bash: |
+    echo "##vso[task.prependpath]$CONDA/bin"
+    conda create -y -n pypy3-env
+    conda install -y -n pypy3-env -c conda-forge pypy3.6=7.3.0
+  displayName: Prepare conda
+- bash: |
+    source activate pypy3-env
+    which pypy3
+    pypy3 -m ensurepip
+    pypy3 -m pip install pytest pytest-cov
+  displayName: Setup pypy3 packages
+- bash: |
+    source activate pypy3-env
+    pypy3 -m pip install .
+  displayName: Build uarray
+- bash: |
+    source activate pypy3-env
+    pytest --pyargs uarray
+  workingDirectory: $(Agent.BuildDirectory)
+  displayName: Test uarray

--- a/uarray/tests/conftest.py
+++ b/uarray/tests/conftest.py
@@ -2,6 +2,18 @@ import sys
 
 
 def pytest_cmdline_preparse(args):
-    if sys.version_info >= (3, 6):
+    try:
+        import pytest_black
+    except ImportError:
+        pass
+    else:
         args.append("--black")
+        print("uarray: Enabling pytest-black")
+
+    try:
+        import pytest_mypy
+    except ImportError:
+        pass
+    else:
         args.append("--mypy")
+        print("uarray: Enabling pytest-mypy")


### PR DESCRIPTION
Some of pypy3's C-API doesn't cast its arguments to `PyObject*` so the implicit
conversion from `py_ref` is never triggered. So, I remove the implicit conversion
operator and manually call `py_ref::get()` as appropriate.