### PR TITLE
Allow __ua_domain__ to be a list of domain strings

### DIFF
--- a/ci/azure-run-clang-format.yml
+++ b/ci/azure-run-clang-format.yml
@@ -6,7 +6,7 @@ steps:
     sudo apt-get install -y clang-format-8
   displayName: Install clang-format
 - bash: |
-    clang-format-8 -i uarray/_uarray_dispatch.cxx
+    clang-format-8 -i uarray/_uarray_dispatch.cxx uarray/small_dynamic_array.h
     if [ "$(git diff)" != "" ]; then
       echo "Detected formatting errors, suggested changes below:"
       git diff

--- a/docs/libauthor_docs.rst
+++ b/docs/libauthor_docs.rst
@@ -20,7 +20,11 @@ the last is optional.
 ``__ua_domain__`` is a string containing the domain of the backend. This is,
 by convention, the name of the module (or one of its dependencies or parents)
 that contains the multimethods. For example, ``scipy`` and ``numpy.fft`` could
-both use the ``numpy`` domain.
+both be in the ``numpy`` domain or one of its subdomains.
+
+Additionally, ``__ua_domain__`` can be a sequence of domains, such as a tuple or
+list of strings. This allows a single backend to implement functions from more
+than one domain.
 
 ``__ua_function__``
 -------------------

--- a/uarray/_uarray_dispatch.cxx
+++ b/uarray/_uarray_dispatch.cxx
@@ -11,7 +11,6 @@
 #include <vector>
 
 
-
 namespace {
 
 /** Handle to a python object that automatically DECREFs */
@@ -257,23 +256,19 @@ LoopReturn backend_for_each_domain(PyObject * backend, Func f) {
 
 template <typename Func>
 LoopReturn backend_for_each_domain_string(PyObject * backend, Func f) {
-  return backend_for_each_domain(
-    backend,
-    [&](PyObject * domain) {
-      auto domain_string = domain_to_string(domain);
-      if (domain_string.empty()) {
-        return LoopReturn::Error;
-      }
-      return f(domain_string);
-    });
+  return backend_for_each_domain(backend, [&](PyObject * domain) {
+    auto domain_string = domain_to_string(domain);
+    if (domain_string.empty()) {
+      return LoopReturn::Error;
+    }
+    return f(domain_string);
+  });
 }
 
 bool backend_validate_ua_domain(PyObject * backend) {
-  const auto res = backend_for_each_domain(
-    backend,
-    [&](PyObject * domain) {
-      return domain_validate(domain) ? LoopReturn::Continue : LoopReturn::Error;
-    });
+  const auto res = backend_for_each_domain(backend, [&](PyObject * domain) {
+    return domain_validate(domain) ? LoopReturn::Continue : LoopReturn::Error;
+  });
   return (res != LoopReturn::Error);
 }
 
@@ -559,7 +554,7 @@ PyObject * set_global_backend(PyObject * /* self */, PyObject * args) {
   }
 
   const auto res =
-    backend_for_each_domain_string(backend, [&](const std::string & domain) {
+      backend_for_each_domain_string(backend, [&](const std::string & domain) {
         backend_options options;
         options.backend = py_ref::ref(backend);
         options.coerce = coerce;
@@ -757,8 +752,8 @@ struct SetBackendContext {
       decltype(ctx_)::BackendLists backend_lists(num_domains);
       int idx = 0;
 
-      const auto ret =
-          backend_for_each_domain_string(backend, [&](const std::string & domain) {
+      const auto ret = backend_for_each_domain_string(
+          backend, [&](const std::string & domain) {
             backend_lists[idx] = &local_domain_map[domain].preferred;
             ++idx;
             return LoopReturn::Continue;
@@ -852,8 +847,8 @@ struct SkipBackendContext {
       decltype(ctx_)::BackendLists backend_lists(num_domains);
       int idx = 0;
 
-      const auto ret =
-          backend_for_each_domain_string(backend, [&](const std::string & domain) {
+      const auto ret = backend_for_each_domain_string(
+          backend, [&](const std::string & domain) {
             backend_lists[idx] = &local_domain_map[domain].skipped;
             ++idx;
             return LoopReturn::Continue;

--- a/uarray/_uarray_dispatch.cxx
+++ b/uarray/_uarray_dispatch.cxx
@@ -1,3 +1,6 @@
+#include "small_dynamic_array.h"
+
+#include <Python.h>
 
 #include <algorithm>
 #include <cstddef>
@@ -7,9 +10,7 @@
 #include <utility>
 #include <vector>
 
-#include <Python.h>
 
-#include "small_dynamic_array.h"
 
 namespace {
 

--- a/uarray/small_dynamic_array.h
+++ b/uarray/small_dynamic_array.h
@@ -3,12 +3,13 @@
 #include <type_traits>
 #include <new>
 #include <cstdlib>
+#include <cassert>
 
 
 /** Fixed size dynamic array with small buffer optimisation */
-template <typename T, size_t SmallCapacity = 1>
+template <typename T, ptrdiff_t SmallCapacity = 1>
 class SmallDynamicArray {
-  Py_ssize_t size_;
+  ptrdiff_t size_;
   union {
     T elements[SmallCapacity];
     T * array;
@@ -74,7 +75,7 @@ public:
   using const_iterator = const value_type *;
   using reference = value_type &;
   using const_reference = const value_type &;
-  using size_type = Py_ssize_t;
+  using size_type = ptrdiff_t;
 
   SmallDynamicArray():
     size_(0)

--- a/uarray/small_dynamic_array.h
+++ b/uarray/small_dynamic_array.h
@@ -1,9 +1,10 @@
 #pragma once
-#include <memory>
-#include <type_traits>
-#include <new>
-#include <cstdlib>
 #include <cassert>
+#include <cstddef>
+#include <cstdlib>
+#include <memory>
+#include <new>
+#include <type_traits>
 
 
 /** Fixed size dynamic array with small buffer optimisation */
@@ -15,12 +16,10 @@ class SmallDynamicArray {
     T * array;
   } storage_;
 
-  bool is_small() const {
-    return size_ <= SmallCapacity;
-  }
+  bool is_small() const { return size_ <= SmallCapacity; }
 
   void destroy_buffer(T * first, T * last) noexcept {
-    for (;first < last; ++first) {
+    for (; first < last; ++first) {
       first->~T();
     }
   }
@@ -29,7 +28,7 @@ class SmallDynamicArray {
     auto cur = first;
     try {
       for (; cur < last; ++cur) {
-        new (cur) T();  // Placement new
+        new (cur) T(); // Placement new
       }
     } catch (...) {
       // If construction failed, destroy already constructed values
@@ -38,8 +37,8 @@ class SmallDynamicArray {
     }
   }
 
-  void move_construct_buffer(T * first, T * last, T * d_first)
-      noexcept(std::is_nothrow_move_constructible<T>::value) {
+  void move_construct_buffer(T * first, T * last, T * d_first) noexcept(
+      std::is_nothrow_move_constructible<T>::value) {
     T * d_cur = d_first;
 
     try {
@@ -54,9 +53,10 @@ class SmallDynamicArray {
 
   void allocate() {
     assert(size_ >= 0);
-    if (is_small()) return;
+    if (is_small())
+      return;
 
-    storage_.array = (T*) malloc(size_ * sizeof(T));
+    storage_.array = (T *)malloc(size_ * sizeof(T));
     if (!storage_.array) {
       throw std::bad_alloc();
     }
@@ -69,7 +69,6 @@ class SmallDynamicArray {
   }
 
 public:
-
   using value_type = T;
   using iterator = value_type *;
   using const_iterator = const value_type *;
@@ -77,14 +76,9 @@ public:
   using const_reference = const value_type &;
   using size_type = ptrdiff_t;
 
-  SmallDynamicArray():
-    size_(0)
-  {
-  }
+  SmallDynamicArray(): size_(0) {}
 
-  explicit SmallDynamicArray(size_t size):
-    size_(size)
-  {
+  explicit SmallDynamicArray(size_t size): size_(size) {
     allocate();
     auto first = begin();
     try {
@@ -95,9 +89,7 @@ public:
     }
   }
 
-  SmallDynamicArray(size_type size, const T & fill_value):
-    size_(size)
-  {
+  SmallDynamicArray(size_type size, const T & fill_value): size_(size) {
     allocate();
     try {
       std::uninitialized_fill_n(begin(), size_, fill_value);
@@ -107,9 +99,7 @@ public:
     }
   }
 
-  SmallDynamicArray(const SmallDynamicArray & copy):
-    size_(copy.size_)
-  {
+  SmallDynamicArray(const SmallDynamicArray & copy): size_(copy.size_) {
     allocate();
     try {
       std::uninitialized_copy_n(copy.begin(), size_, begin());
@@ -119,9 +109,9 @@ public:
     }
   }
 
-  SmallDynamicArray(SmallDynamicArray && move)
-      noexcept(std::is_nothrow_move_constructible<T>::value):
-      size_(move.size_) {
+  SmallDynamicArray(SmallDynamicArray && move) noexcept(
+      std::is_nothrow_move_constructible<T>::value)
+      : size_(move.size_) {
     if (!move.is_small()) {
       storage_.array = move.storage_.array;
       move.storage_.array = nullptr;
@@ -149,8 +139,9 @@ public:
     deallocate();
   }
 
-  SmallDynamicArray & operator = (const SmallDynamicArray & copy) {
-    if (&copy == this) return *this;
+  SmallDynamicArray & operator=(const SmallDynamicArray & copy) {
+    if (&copy == this)
+      return *this;
 
     auto first = begin();
     destroy_buffer(first, first + size_);
@@ -174,9 +165,10 @@ public:
     return *this;
   }
 
-  SmallDynamicArray & operator = (SmallDynamicArray && move)
-      noexcept(std::is_nothrow_move_constructible<T>::value) {
-    if (&move == this) return *this;
+  SmallDynamicArray & operator=(SmallDynamicArray && move) noexcept(
+      std::is_nothrow_move_constructible<T>::value) {
+    if (&move == this)
+      return *this;
 
     if (!move.is_small()) {
       storage_.array = move.storage_.array;
@@ -214,28 +206,22 @@ public:
     return is_small() ? &storage_.elements[0] : storage_.array;
   }
 
-  iterator end() {
-    return begin() + size_;
-  }
+  iterator end() { return begin() + size_; }
 
-  const_iterator cend() const {
-    return cbegin() + size_;
-  }
+  const_iterator cend() const { return cbegin() + size_; }
 
   const_iterator begin() const { return cbegin(); }
 
   const_iterator end() const { return cend(); }
 
-  size_type size() const {
-    return size_;
-  }
+  size_type size() const { return size_; }
 
-  const_reference operator[] (size_type idx) const {
+  const_reference operator[](size_type idx) const {
     assert(0 < idx && idx < size_);
     return begin()[idx];
   }
 
-  reference operator[] (size_type idx) {
+  reference operator[](size_type idx) {
     assert(0 < idx && idx < size);
     return begin()[idx];
   }

--- a/uarray/small_dynamic_array.h
+++ b/uarray/small_dynamic_array.h
@@ -24,7 +24,8 @@ class SmallDynamicArray {
     }
   }
 
-  void default_construct_buffer(T * first, T * last) {
+  void default_construct_buffer(T * first, T * last) noexcept(
+      std::is_nothrow_destructible<T>::value) {
     auto cur = first;
     try {
       for (; cur < last; ++cur) {
@@ -133,19 +134,13 @@ public:
     move.size_ = 0;
   }
 
-  ~SmallDynamicArray() {
-    auto first = begin();
-    destroy_buffer(first, first + size_);
-    deallocate();
-  }
+  ~SmallDynamicArray() { clear(); }
 
   SmallDynamicArray & operator=(const SmallDynamicArray & copy) {
     if (&copy == this)
       return *this;
 
-    auto first = begin();
-    destroy_buffer(first, first + size_);
-    deallocate();
+    clear();
 
     size_ = copy.size;
     try {
@@ -178,9 +173,7 @@ public:
       return *this;
     }
 
-    auto first = begin();
-    destroy_buffer(first, first + size_);
-    deallocate();
+    clear();
 
     size_ = move.size_;
     auto m_first = move.begin();
@@ -196,6 +189,13 @@ public:
     destroy_buffer(m_first, m_first + size_);
     move.size_ = 0;
     return *this;
+  }
+
+  void clear() noexcept(std::is_nothrow_destructible<T>::value) {
+    auto first = begin();
+    destroy_buffer(first, first + size_);
+    deallocate();
+    size_ = 0;
   }
 
   iterator begin() {

--- a/uarray/small_dynamic_array.h
+++ b/uarray/small_dynamic_array.h
@@ -1,0 +1,241 @@
+#pragma once
+#include <memory>
+#include <type_traits>
+#include <new>
+#include <cstdlib>
+
+
+/** Fixed size dynamic array with small buffer optimisation */
+template <typename T, size_t SmallCapacity = 1>
+class SmallDynamicArray {
+  Py_ssize_t size_;
+  union {
+    T elements[SmallCapacity];
+    T * array;
+  } storage_;
+
+  bool is_small() const {
+    return size_ <= SmallCapacity;
+  }
+
+  void destroy_buffer(T * first, T * last) noexcept {
+    for (;first < last; ++first) {
+      first->~T();
+    }
+  }
+
+  void default_construct_buffer(T * first, T * last) {
+    auto cur = first;
+    try {
+      for (; cur < last; ++cur) {
+        new (cur) T();  // Placement new
+      }
+    } catch (...) {
+      // If construction failed, destroy already constructed values
+      destroy_buffer(first, cur);
+      throw;
+    }
+  }
+
+  void move_construct_buffer(T * first, T * last, T * d_first)
+      noexcept(std::is_nothrow_move_constructible<T>::value) {
+    T * d_cur = d_first;
+
+    try {
+      for (; first < last; ++first, ++d_cur) {
+        new (d_cur) T(std::move(*first)); // Placement new
+      }
+    } catch (...) {
+      destroy_buffer(d_first, d_cur);
+      throw;
+    }
+  }
+
+  void allocate() {
+    assert(size_ >= 0);
+    if (is_small()) return;
+
+    storage_.array = (T*) malloc(size_ * sizeof(T));
+    if (!storage_.array) {
+      throw std::bad_alloc();
+    }
+  }
+
+  void deallocate() noexcept {
+    if (!is_small()) {
+      free(storage_.array);
+    }
+  }
+
+public:
+
+  using value_type = T;
+  using iterator = value_type *;
+  using const_iterator = const value_type *;
+  using reference = value_type &;
+  using const_reference = const value_type &;
+  using size_type = Py_ssize_t;
+
+  SmallDynamicArray():
+    size_(0)
+  {
+  }
+
+  explicit SmallDynamicArray(size_t size):
+    size_(size)
+  {
+    allocate();
+    auto first = begin();
+    try {
+      default_construct_buffer(first, first + size_);
+    } catch (...) {
+      deallocate();
+      throw;
+    }
+  }
+
+  SmallDynamicArray(size_type size, const T & fill_value):
+    size_(size)
+  {
+    allocate();
+    try {
+      std::uninitialized_fill_n(begin(), size_, fill_value);
+    } catch (...) {
+      deallocate();
+      throw;
+    }
+  }
+
+  SmallDynamicArray(const SmallDynamicArray & copy):
+    size_(copy.size_)
+  {
+    allocate();
+    try {
+      std::uninitialized_copy_n(copy.begin(), size_, begin());
+    } catch (...) {
+      deallocate();
+      throw;
+    }
+  }
+
+  SmallDynamicArray(SmallDynamicArray && move)
+      noexcept(std::is_nothrow_move_constructible<T>::value):
+      size_(move.size_) {
+    if (!move.is_small()) {
+      storage_.array = move.storage_.array;
+      move.storage_.array = nullptr;
+      move.storage_.size = 0;
+      return;
+    }
+
+    auto m_first = move.begin();
+    try {
+      move_construct_buffer(m_first, m_first + size_, begin());
+    } catch (...) {
+      destroy_buffer(m_first, m_first + size_);
+      move.size_ = 0;
+      size_ = 0;
+      throw;
+    }
+
+    destroy_buffer(&move.storage_.elements[0], &move.storage_.elements[size_]);
+    move.size_ = 0;
+  }
+
+  ~SmallDynamicArray() {
+    auto first = begin();
+    destroy_buffer(first, first + size_);
+    deallocate();
+  }
+
+  SmallDynamicArray & operator = (const SmallDynamicArray & copy) {
+    if (&copy == this) return *this;
+
+    auto first = begin();
+    destroy_buffer(first, first + size_);
+    deallocate();
+
+    size_ = copy.size;
+    try {
+      allocate();
+    } catch (...) {
+      size_ = 0;
+      throw;
+    }
+
+    try {
+      std::uninitialized_copy_n(copy.begin(), size_, begin());
+    } catch (...) {
+      deallocate();
+      size_ = 0;
+      throw;
+    }
+    return *this;
+  }
+
+  SmallDynamicArray & operator = (SmallDynamicArray && move)
+      noexcept(std::is_nothrow_move_constructible<T>::value) {
+    if (&move == this) return *this;
+
+    if (!move.is_small()) {
+      storage_.array = move.storage_.array;
+      size_ = move.size_;
+      move.storage_.array = nullptr;
+      move.size_ = 0;
+      return *this;
+    }
+
+    auto first = begin();
+    destroy_buffer(first, first + size_);
+    deallocate();
+
+    size_ = move.size_;
+    auto m_first = move.begin();
+    try {
+      move_construct_buffer(m_first, m_first + size_, begin());
+    } catch (...) {
+      destroy_buffer(m_first, m_first + size_);
+      move.size_ = 0;
+      size_ = 0;
+      throw;
+    }
+
+    destroy_buffer(m_first, m_first + size_);
+    move.size_ = 0;
+    return *this;
+  }
+
+  iterator begin() {
+    return is_small() ? &storage_.elements[0] : storage_.array;
+  }
+
+  const_iterator cbegin() const {
+    return is_small() ? &storage_.elements[0] : storage_.array;
+  }
+
+  iterator end() {
+    return begin() + size_;
+  }
+
+  const_iterator cend() const {
+    return cbegin() + size_;
+  }
+
+  const_iterator begin() const { return cbegin(); }
+
+  const_iterator end() const { return cend(); }
+
+  size_type size() const {
+    return size_;
+  }
+
+  const_reference operator[] (size_type idx) const {
+    assert(0 < idx && idx < size_);
+    return begin()[idx];
+  }
+
+  reference operator[] (size_type idx) {
+    assert(0 < idx && idx < size);
+    return begin()[idx];
+  }
+};

--- a/uarray/tests/test_uarray.py
+++ b/uarray/tests/test_uarray.py
@@ -401,13 +401,10 @@ def test_multidomain_backends():
     def assert_backend_active(backend):
         assert all(mms[i]() is backend.ret for i in range(len(mms)))
 
-
-
     assert_no_backends()
 
     with ua.set_backend(be):
         assert_backend_active(be)
-
 
     ua.set_global_backend(be)
     assert_backend_active(be)
@@ -430,5 +427,3 @@ def test_multidomain_backends():
 
     ua.register_backend(be)
     assert_backend_active(be)
-
-

--- a/uarray/tests/test_uarray.py
+++ b/uarray/tests/test_uarray.py
@@ -421,7 +421,7 @@ def test_multidomain_backends():
             mms[i]()
 
         for j in range(i + 1, len(mms)):
-            assert mms[j]() == be.ret
+            assert mms[j]() is be.ret
 
     assert_no_backends()
 


### PR DESCRIPTION
Closes #239

This allows a backend to implement multiple domains by making `__ua_domain__` a list of domains:
```python
__ua_domain__ = ["domain_a", "domain_b"]
```

TODO:

- [x] More test coverage (`skip_backend`, `register_backend`, etc.)
- [x] Benchmark function call performance. (`context_helper` in particular is used for functions with default implementations)
- [x] Validate `__ua_domain__` upfront before modifying `uarray`'s state.
- [x] Update documentation