### PR TITLE
Fix refcount and GC issues

### DIFF
--- a/uarray/_uarray_dispatch.cxx
+++ b/uarray/_uarray_dispatch.cxx
@@ -713,6 +713,7 @@ struct SetBackendContext {
   context_helper<backend_options> ctx_;
 
   static void dealloc(SetBackendContext * self) {
+    PyObject_GC_UnTrack(self);
     self->~SetBackendContext();
     Py_TYPE(self)->tp_free(self);
   }
@@ -810,6 +811,7 @@ struct SkipBackendContext {
   context_helper<py_ref> ctx_;
 
   static void dealloc(SkipBackendContext * self) {
+    PyObject_GC_UnTrack(self);
     self->~SkipBackendContext();
     Py_TYPE(self)->tp_free(self);
   }
@@ -1570,7 +1572,7 @@ PyObject * determine_backend(PyObject * /*self*/, PyObject * args) {
       });
 
   if (result != LoopReturn::Continue)
-    return selected_backend.get();
+    return selected_backend.release();
 
   // All backends failed, raise an error
   PyErr_SetString(
@@ -1665,7 +1667,7 @@ PyTypeObject SetBackendContextType = {
     0,                                         /* tp_getattro */
     0,                                         /* tp_setattro */
     0,                                         /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                        /* tp_flags */
+    (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC), /* tp_flags */
     0,                                         /* tp_doc */
     (traverseproc)SetBackendContext::traverse, /* tp_traverse */
     0,                                         /* tp_clear */
@@ -1716,7 +1718,7 @@ PyTypeObject SkipBackendContextType = {
     0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                         /* tp_flags */
+    (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC),  /* tp_flags */
     0,                                          /* tp_doc */
     (traverseproc)SkipBackendContext::traverse, /* tp_traverse */
     0,                                          /* tp_clear */


### PR DESCRIPTION
Should fix the segfaults in Quansight-Labs/udiff#31

Returning `selected_backend.get()` instead of `.release()` from `determine_backend` meant the refcount was decreased without dropping the reference. The net result is decreasing the refcount of the backend once for each call to `determine_backend`. Eventually it gets GC'd and the python interpreter accesses invalid memory causing the segfault.

The GC issues are unrelated but were spotted while debugging this. The context managers had `tp_traverse` defined but the GC will only use these if the type has the `Py_TPFLAGS_HAVE_GC` flag set. 