### PR TITLE
Update broken link in documentation

### DIFF
--- a/docs/multimethod_docs.rst
+++ b/docs/multimethod_docs.rst
@@ -54,7 +54,7 @@ and it returns an ``args``/``kwargs`` pair. We realise this is a hard problem
 in general, so we have provided a few simplifications, such as that the
 default-valued keyword arguments will be removed from the list.
 
-We recommend following the pattern in `here <https://github.com/Quansight-Labs/uarray/blob/master/unumpy/_multimethods.py>`_
+We recommend following the pattern in `here <https://github.com/Quansight-Labs/unumpy/blob/master/unumpy/_multimethods.py>`_
 for optimal operation: passing the ``args``/``kwargs`` into a function with a
 similar signature and then return the modified ``args``/``kwargs``.
 


### PR DESCRIPTION
[This link](https://github.com/Quansight-Labs/uarray/blob/master/unumpy/_multimethods.py) under [Argument Replacer](https://uarray.org/en/latest/multimethod_docs.html#argument-replacer) is dead and is updated.