### PR TITLE
Accelerate multimethod-calls with Vectorcall protocol

### DIFF
--- a/ci/azure-run-clang-format.yml
+++ b/ci/azure-run-clang-format.yml
@@ -7,6 +7,7 @@ steps:
   displayName: Install clang-format
 - bash: |
     clang-format-8 -i uarray/_uarray_dispatch.cxx uarray/small_dynamic_array.h
+    clang-format-8 -i uarray/vectorcall.cxx uarray/vectorcall.h
     if [ "$(git diff)" != "" ]; then
       echo "Detected formatting errors, suggested changes below:"
       git diff

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,10 @@ cmdclass.update(versioneer.get_cmdclass())
 
 
 extensions = [
-    Extension("uarray._uarray", sources=["uarray/_uarray_dispatch.cxx"], language="c++")
+    Extension("uarray._uarray",
+              sources=["uarray/_uarray_dispatch.cxx", "uarray/vectorcall.cxx"],
+              depends=["uarray/small_dynamic_array.h", "uarray/vectorcall.h"],
+              language="c++")
 ]
 
 setup(

--- a/uarray/_uarray_dispatch.cxx
+++ b/uarray/_uarray_dispatch.cxx
@@ -318,11 +318,8 @@ struct BackendState {
   static PyObject * unpickle_(PyObject * cls, PyObject * args) {
     try {
       PyObject *py_locals, *py_global;
-      py_ref empty_tuple = py_ref::steal(PyTuple_New(0));
-      if (!empty_tuple)
-        return nullptr;
-
-      py_ref ref = py_ref::steal(PyObject_Call(cls, empty_tuple.get(), NULL));
+      py_ref ref =
+          py_ref::steal(Q_PyObject_Vectorcall(cls, nullptr, 0, nullptr));
       BackendState * output = reinterpret_cast<BackendState *>(ref.get());
       if (output == nullptr)
         return nullptr;
@@ -1475,12 +1472,8 @@ PyTypeObject BackendStateType = {
 };
 
 PyObject * get_state(PyObject * /* self */, PyObject * /* args */) {
-  py_ref new_tuple = py_ref::steal(PyTuple_New(0));
-  if (!new_tuple)
-    return nullptr;
-
-  py_ref ref = py_ref::steal(PyObject_Call(
-      reinterpret_cast<PyObject *>(&BackendStateType), new_tuple.get(), NULL));
+  py_ref ref = py_ref::steal(Q_PyObject_Vectorcall(
+      reinterpret_cast<PyObject *>(&BackendStateType), nullptr, 0, nullptr));
   BackendState * output = reinterpret_cast<BackendState *>(ref.get());
 
   output->locals = local_domain_map;

--- a/uarray/_uarray_dispatch.cxx
+++ b/uarray/_uarray_dispatch.cxx
@@ -1,4 +1,5 @@
 #include "small_dynamic_array.h"
+#include "vectorcall.h"
 
 #include <Python.h>
 
@@ -91,6 +92,11 @@ py_ref py_make_tuple(const Ts &... args) {
 }
 
 py_ref py_bool(bool input) { return py_ref::ref(input ? Py_True : Py_False); }
+
+template <typename T, size_t N>
+constexpr size_t array_size(const T (&array)[N]) {
+  return N;
+}
 
 struct backend_options {
   py_ref backend;
@@ -1147,11 +1153,8 @@ py_ref Function::canonicalize_kwargs(PyObject * kwargs) {
 
 py_func_args Function::replace_dispatchables(
     PyObject * backend, PyObject * args, PyObject * kwargs, PyObject * coerce) {
-  auto ua_convert =
-      py_ref::steal(PyObject_GetAttr(backend, identifiers.ua_convert.get()));
-
-  if (!ua_convert) {
-    PyErr_Clear();
+  auto has_ua_convert = PyObject_HasAttr(backend, identifiers.ua_convert.get());
+  if (!has_ua_convert) {
     return {py_ref::ref(args), py_ref::ref(kwargs)};
   }
 
@@ -1160,9 +1163,10 @@ py_func_args Function::replace_dispatchables(
   if (!dispatchables)
     return {};
 
-  auto convert_args = py_make_tuple(dispatchables, coerce);
-  auto res = py_ref::steal(
-      PyObject_Call(ua_convert.get(), convert_args.get(), nullptr));
+  PyObject * convert_args[] = {backend, dispatchables.get(), coerce};
+  auto res = py_ref::steal(Q_PyObject_VectorcallMethod(
+      identifiers.ua_convert.get(), convert_args,
+      array_size(convert_args) | Q_PY_VECTORCALL_ARGUMENTS_OFFSET, nullptr));
   if (!res) {
     return {};
   }
@@ -1175,12 +1179,11 @@ py_func_args Function::replace_dispatchables(
   if (!replaced_args)
     return {};
 
-  auto replacer_args = py_make_tuple(args, kwargs, replaced_args);
-  if (!replacer_args)
-    return {};
-
-  res = py_ref::steal(
-      PyObject_Call(replacer_.get(), replacer_args.get(), nullptr));
+  PyObject * replacer_args[] = {nullptr, args, kwargs, replaced_args.get()};
+  res = py_ref::steal(Q_PyObject_Vectorcall(
+      replacer_.get(), &replacer_args[1],
+      (array_size(replacer_args) - 1) | Q_PY_VECTORCALL_ARGUMENTS_OFFSET,
+      nullptr));
   if (!res)
     return {};
 
@@ -1263,18 +1266,11 @@ PyObject * Function::call(PyObject * args_, PyObject * kwargs_) {
         if (new_args.args == nullptr)
           return LoopReturn::Error;
 
-        auto ua_function = py_ref::steal(
-            PyObject_GetAttr(backend, identifiers.ua_function.get()));
-        if (!ua_function)
-          return LoopReturn::Error;
-
-        auto ua_func_args = py_make_tuple(
-            reinterpret_cast<PyObject *>(this), new_args.args, new_args.kwargs);
-        if (!ua_func_args)
-          return LoopReturn::Error;
-
-        result = py_ref::steal(
-            PyObject_Call(ua_function.get(), ua_func_args.get(), nullptr));
+        PyObject * args[] = {backend, reinterpret_cast<PyObject *>(this),
+                             new_args.args.get(), new_args.kwargs.get()};
+        result = py_ref::steal(Q_PyObject_VectorcallMethod(
+            identifiers.ua_function.get(), args,
+            array_size(args) | Q_PY_VECTORCALL_ARGUMENTS_OFFSET, nullptr));
 
         // raise BackendNotImplemeted is equivalent to return NotImplemented
         if (!result &&
@@ -1543,22 +1539,22 @@ PyObject * determine_backend(PyObject * /*self*/, PyObject * args) {
   py_ref selected_backend;
   auto result = for_each_backend_in_domain(
       domain, [&](PyObject * backend, bool coerce_backend) {
-        auto ua_convert = py_ref::steal(
-            PyObject_GetAttr(backend, identifiers.ua_convert.get()));
+        auto has_ua_convert =
+            PyObject_HasAttr(backend, identifiers.ua_convert.get());
 
-        if (!ua_convert) {
+        if (!has_ua_convert) {
           // If no __ua_convert__, assume it won't accept the type
-          PyErr_Clear();
           return LoopReturn::Continue;
         }
 
-        auto convert_args = py_make_tuple(
-            dispatchables_tuple, py_bool(coerce && coerce_backend));
-        if (!convert_args)
-          return LoopReturn::Error;
+        PyObject * convert_args[] = {backend, dispatchables_tuple.get(),
+                                     (coerce && coerce_backend) ? Py_True
+                                                                : Py_False};
 
-        auto res = py_ref::steal(
-            PyObject_Call(ua_convert.get(), convert_args.get(), nullptr));
+        auto res = py_ref::steal(Q_PyObject_VectorcallMethod(
+            identifiers.ua_convert.get(), convert_args,
+            array_size(convert_args) | Q_PY_VECTORCALL_ARGUMENTS_OFFSET,
+            nullptr));
         if (!res) {
           return LoopReturn::Error;
         }
@@ -1599,44 +1595,45 @@ PyGetSetDef Function_getset[] = {
 };
 
 PyTypeObject FunctionType = {
-    PyVarObject_HEAD_INIT(NULL, 0)             /* boilerplate */
-    "uarray._Function",                        /* tp_name */
-    sizeof(Function),                          /* tp_basicsize */
-    0,                                         /* tp_itemsize */
-    (destructor)Function::dealloc,             /* tp_dealloc */
-    0,                                         /* tp_print */
-    0,                                         /* tp_getattr */
-    0,                                         /* tp_setattr */
-    0,                                         /* tp_reserved */
-    (reprfunc)Function::repr,                  /* tp_repr */
-    0,                                         /* tp_as_number */
-    0,                                         /* tp_as_sequence */
-    0,                                         /* tp_as_mapping */
-    0,                                         /* tp_hash  */
-    (ternaryfunc)Function_call,                /* tp_call */
-    0,                                         /* tp_str */
-    PyObject_GenericGetAttr,                   /* tp_getattro */
-    PyObject_GenericSetAttr,                   /* tp_setattro */
-    0,                                         /* tp_as_buffer */
-    (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC), /* tp_flags */
-    0,                                         /* tp_doc */
-    (traverseproc)Function::traverse,          /* tp_traverse */
-    (inquiry)Function::clear,                  /* tp_clear */
-    0,                                         /* tp_richcompare */
-    0,                                         /* tp_weaklistoffset */
-    0,                                         /* tp_iter */
-    0,                                         /* tp_iternext */
-    0,                                         /* tp_methods */
-    0,                                         /* tp_members */
-    Function_getset,                           /* tp_getset */
-    0,                                         /* tp_base */
-    0,                                         /* tp_dict */
-    Function::descr_get,                       /* tp_descr_get */
-    0,                                         /* tp_descr_set */
-    offsetof(Function, dict_),                 /* tp_dictoffset */
-    (initproc)Function::init,                  /* tp_init */
-    0,                                         /* tp_alloc */
-    Function::new_,                            /* tp_new */
+    PyVarObject_HEAD_INIT(NULL, 0) /* boilerplate */
+    /* tp_name= */ "uarray._Function",
+    /* tp_basicsize= */ sizeof(Function),
+    /* tp_itemsize= */ 0,
+    /* tp_dealloc= */ (destructor)Function::dealloc,
+    /* tp_print= */ 0,
+    /* tp_getattr= */ 0,
+    /* tp_setattr= */ 0,
+    /* tp_reserved= */ 0,
+    /* tp_repr= */ (reprfunc)Function::repr,
+    /* tp_as_number= */ 0,
+    /* tp_as_sequence= */ 0,
+    /* tp_as_mapping= */ 0,
+    /* tp_hash= */ 0,
+    /* tp_call= */ (ternaryfunc)Function_call,
+    /* tp_str= */ 0,
+    /* tp_getattro= */ PyObject_GenericGetAttr,
+    /* tp_setattro= */ PyObject_GenericSetAttr,
+    /* tp_as_buffer= */ 0,
+    /* tp_flags= */
+    (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Q_Py_TPFLAGS_METHOD_DESCRIPTOR),
+    /* tp_doc= */ 0,
+    /* tp_traverse= */ (traverseproc)Function::traverse,
+    /* tp_clear= */ (inquiry)Function::clear,
+    /* tp_richcompare= */ 0,
+    /* tp_weaklistoffset= */ 0,
+    /* tp_iter= */ 0,
+    /* tp_iternext= */ 0,
+    /* tp_methods= */ 0,
+    /* tp_members= */ 0,
+    /* tp_getset= */ Function_getset,
+    /* tp_base= */ 0,
+    /* tp_dict= */ 0,
+    /* tp_descr_get= */ Function::descr_get,
+    /* tp_descr_set= */ 0,
+    /* tp_dictoffset= */ offsetof(Function, dict_),
+    /* tp_init= */ (initproc)Function::init,
+    /* tp_alloc= */ 0,
+    /* tp_new= */ Function::new_,
 };
 
 

--- a/uarray/vectorcall.cxx
+++ b/uarray/vectorcall.cxx
@@ -36,6 +36,7 @@ static PyObject * build_kwarg_dict(
   return dict;
 }
 #elif (PY_VERSION_HEX < 0x03090000)
+// clang-format off
 
 static int is_method_descr(PyTypeObject* descr_tp) {
     return (
@@ -139,6 +140,7 @@ static int _PyObject_GetMethod(PyObject *obj, PyObject *name, PyObject **method)
     return 0;
 }
 
+// clang-format on
 #endif /* PYPY_VERSION */
 
 

--- a/uarray/vectorcall.cxx
+++ b/uarray/vectorcall.cxx
@@ -35,14 +35,110 @@ static PyObject * build_kwarg_dict(
   }
   return dict;
 }
-#elif ((PY_VERSION_HEX >= 0x03070000) && (PY_VERSION_HEX < 0x03090000))
-#  ifdef __cplusplus
-extern "C" {
-#  endif
-extern int _PyObject_GetMethod(PyObject *, PyObject *, PyObject **);
-#  ifdef __cplusplus
+#elif (PY_VERSION_HEX < 0x03090000)
+
+static int is_method_descr(PyTypeObject* descr_tp) {
+    return (
+        (descr_tp->tp_flags & Q_Py_TPFLAGS_METHOD_DESCRIPTOR) != 0 ||
+        (descr_tp == &PyFunction_Type) ||
+        (descr_tp == &PyMethodDescr_Type));
 }
-#  endif
+
+/* The below code is derivative of CPython source, and is taken because
+_PyObject_GetMethod is not exported from shared objects.
+
+Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021 Python Software Foundation;
+All Rights Reserved
+*/
+
+/* Specialized version of _PyObject_GenericGetAttrWithDict
+   specifically for the LOAD_METHOD opcode.
+
+   Return 1 if a method is found, 0 if it's a regular attribute
+   from __dict__ or something returned by using a descriptor
+   protocol.
+
+   `method` will point to the resolved attribute or NULL.  In the
+   latter case, an error will be set.
+*/
+static int _PyObject_GetMethod(PyObject *obj, PyObject *name, PyObject **method)
+{
+    PyTypeObject *tp = Py_TYPE(obj);
+    PyObject *descr;
+    descrgetfunc f = NULL;
+    PyObject **dictptr, *dict;
+    PyObject *attr;
+    int meth_found = 0;
+
+    assert(*method == NULL);
+
+    if (Py_TYPE(obj)->tp_getattro != PyObject_GenericGetAttr
+            || !PyUnicode_Check(name)) {
+        *method = PyObject_GetAttr(obj, name);
+        return 0;
+    }
+
+    if (tp->tp_dict == NULL && PyType_Ready(tp) < 0)
+        return 0;
+
+    descr = _PyType_Lookup(tp, name);
+    if (descr != NULL) {
+        Py_INCREF(descr);
+        if (is_method_descr(Py_TYPE(descr))) {
+            meth_found = 1;
+        } else {
+            f = Py_TYPE(descr)->tp_descr_get;
+            if (f != NULL && PyDescr_IsData(descr)) {
+                *method = f(descr, obj, (PyObject *)Py_TYPE(obj));
+                Py_DECREF(descr);
+                return 0;
+            }
+        }
+    }
+
+    dictptr = _PyObject_GetDictPtr(obj);
+    if (dictptr != NULL && (dict = *dictptr) != NULL) {
+        Py_INCREF(dict);
+        attr = PyDict_GetItemWithError(dict, name);
+        if (attr != NULL) {
+            Py_INCREF(attr);
+            *method = attr;
+            Py_DECREF(dict);
+            Py_XDECREF(descr);
+            return 0;
+        }
+        else {
+            Py_DECREF(dict);
+            if (PyErr_Occurred()) {
+                Py_XDECREF(descr);
+                return 0;
+            }
+        }
+    }
+
+    if (meth_found) {
+        *method = descr;
+        return 1;
+    }
+
+    if (f != NULL) {
+        *method = f(descr, obj, (PyObject *)Py_TYPE(obj));
+        Py_DECREF(descr);
+        return 0;
+    }
+
+    if (descr != NULL) {
+        *method = descr;
+        return 0;
+    }
+
+    PyErr_Format(PyExc_AttributeError,
+                 "'%.50s' object has no attribute '%U'",
+                 tp->tp_name, name);
+    return 0;
+}
+
 #endif /* PYPY_VERSION */
 
 
@@ -101,7 +197,7 @@ PyObject * Q_PyObject_VectorcallDict(
 PyObject * Q_PyObject_VectorcallMethod(
     PyObject * name, PyObject * const * args, size_t nargsf,
     PyObject * kwnames) {
-#if (defined(PYPY_VERSION) || (PY_VERSION_HEX < 0x03070000))
+#ifdef PYPY_VERSION
   PyObject * callable = PyObject_GetAttr(args[0], name);
   if (!callable) {
     return NULL;
@@ -112,7 +208,7 @@ PyObject * Q_PyObject_VectorcallMethod(
   return result;
 #elif (PY_VERSION_HEX >= 0x03090000)
   return PyObject_VectorcallMethod(name, args, nargsf, kwnames);
-#else /* (PY_VERSION_HEX >= 0x03070000) */
+#else
   /* Private CPython code for CALL_METHOD opcode */
   PyObject * callable = NULL;
   int unbound = _PyObject_GetMethod(args[0], name, &callable);

--- a/uarray/vectorcall.cxx
+++ b/uarray/vectorcall.cxx
@@ -1,0 +1,137 @@
+#include "vectorcall.h"
+
+#ifdef PYPY_VERSION
+
+/* PyPy doesn't have any support for Vectorcall/FastCall.
+ * These helpers are for translating to PyObject_Call. */
+
+static PyObject * build_arg_tuple(PyObject * const * args, Py_ssize_t nargs) {
+  PyObject * tuple = PyTuple_New(nargs);
+  if (!tuple) {
+    return NULL;
+  }
+
+  for (Py_ssize_t i = 0; i < nargs; ++i) {
+    Py_INCREF(args[i]); /* SET_ITEM steals a reference */
+    PyTuple_SET_ITEM(tuple, i, args[i]);
+  }
+  return tuple;
+}
+
+static PyObject * build_kwarg_dict(
+    PyObject * const * args, PyObject * names, Py_ssize_t nargs) {
+  PyObject * dict = PyDict_New();
+  if (!dict) {
+    return NULL;
+  }
+
+  for (Py_ssize_t i = 0; i < nargs; ++i) {
+    PyObject * key = PyTuple_GET_ITEM(names, i);
+    int success = PyDict_SetItem(dict, key, args[i]);
+    if (success == -1) {
+      Py_DECREF(dict);
+      return NULL;
+    }
+  }
+  return dict;
+}
+#elif ((PY_VERSION_HEX >= 0x03070000) && (PY_VERSION_HEX < 0x03090000))
+#  ifdef __cplusplus
+extern "C" {
+#  endif
+extern int _PyObject_GetMethod(PyObject *, PyObject *, PyObject **);
+#  ifdef __cplusplus
+}
+#  endif
+#endif /* PYPY_VERSION */
+
+
+Py_ssize_t Q_PyVectorcall_NARGS(size_t n) {
+  return n & (~Q_PY_VECTORCALL_ARGUMENTS_OFFSET);
+}
+
+PyObject * Q_PyObject_Vectorcall(
+    PyObject * callable, PyObject * const * args, size_t nargsf,
+    PyObject * kwnames) {
+#ifdef PYPY_VERSION
+  PyObject * dict = NULL;
+  Py_ssize_t nargs = Q_PyVectorcall_NARGS(nargsf);
+  if (kwnames) {
+    Py_ssize_t nkwargs = PyTuple_GET_SIZE(kwnames);
+    dict = build_kwarg_dict(&args[nargs - nkwargs], kwnames, nkwargs);
+    if (!dict) {
+      return NULL;
+    }
+    nargs -= nkwargs;
+  }
+  PyObject * ret = Q_PyObject_VectorcallDict(callable, args, nargs, dict);
+  Py_XDECREF(dict);
+  return ret;
+#elif (PY_VERSION_HEX >= 0x03090000)
+  return PyObject_Vectorcall(callable, args, nargsf, kwnames);
+#elif (PY_VERSION_HEX >= 0x03080000)
+  return _PyObject_Vectorcall(callable, args, nargsf, kwnames);
+#else
+  Py_ssize_t nargs = Q_PyVectorcall_NARGS(nargsf);
+  return _PyObject_FastCallKeywords(
+      callable, (PyObject **)args, nargs, kwnames);
+#endif
+}
+
+PyObject * Q_PyObject_VectorcallDict(
+    PyObject * callable, PyObject * const * args, size_t nargsf,
+    PyObject * kwdict) {
+#ifdef PYPY_VERSION
+  Py_ssize_t nargs = Q_PyVectorcall_NARGS(nargsf);
+  PyObject * tuple = build_arg_tuple(args, nargs);
+  if (!tuple) {
+    return NULL;
+  }
+  PyObject * ret = PyObject_Call(callable, tuple, kwdict);
+  Py_DECREF(tuple);
+  return ret;
+#elif (PY_VERSION_HEX >= 0x03090000)
+  return PyObject_VectorcallDict(callable, args, nargsf, kwdict);
+#else
+  Py_ssize_t nargs = Q_PyVectorcall_NARGS(nargsf);
+  return _PyObject_FastCallDict(callable, (PyObject **)args, nargs, kwdict);
+#endif
+}
+
+PyObject * Q_PyObject_VectorcallMethod(
+    PyObject * name, PyObject * const * args, size_t nargsf,
+    PyObject * kwnames) {
+#if (defined(PYPY_VERSION) || (PY_VERSION_HEX < 0x03070000))
+  PyObject * callable = PyObject_GetAttr(args[0], name);
+  if (!callable) {
+    return NULL;
+  }
+  PyObject * result =
+      Q_PyObject_Vectorcall(callable, &args[1], nargsf - 1, kwnames);
+  Py_DECREF(callable);
+  return result;
+#elif (PY_VERSION_HEX >= 0x03090000)
+  return PyObject_VectorcallMethod(name, args, nargsf, kwnames);
+#else /* (PY_VERSION_HEX >= 0x03070000) */
+  /* Private CPython code for CALL_METHOD opcode */
+  PyObject * callable = NULL;
+  int unbound = _PyObject_GetMethod(args[0], name, &callable);
+  if (callable == NULL) {
+    return NULL;
+  }
+
+  if (unbound) {
+    /* We must remove PY_VECTORCALL_ARGUMENTS_OFFSET since
+     * that would be interpreted as allowing to change args[-1] */
+    nargsf &= ~Q_PY_VECTORCALL_ARGUMENTS_OFFSET;
+  } else {
+    /* Skip "self". We can keep PY_VECTORCALL_ARGUMENTS_OFFSET since
+     * args[-1] in the onward call is args[0] here. */
+    args++;
+    nargsf--;
+  }
+  PyObject * result = Q_PyObject_Vectorcall(callable, args, nargsf, kwnames);
+  Py_DECREF(callable);
+  return result;
+#endif
+}

--- a/uarray/vectorcall.h
+++ b/uarray/vectorcall.h
@@ -1,0 +1,48 @@
+#pragma once
+#include <Python.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// True if python supports vectorcall on custom classes
+#define Q_HAS_VECTORCALL                                                       \
+  (!defined(PYPY_VERSION) && (PY_VERSION_HEX >= 0x03080000))
+
+#if !Q_HAS_VECTORCALL
+#  define Q_Py_TPFLAGS_HAVE_VECTORCALL 0
+#elif (PY_VERSION_HEX >= 0x03090000)
+#  define Q_Py_TPFLAGS_HAVE_VECTORCALL Py_TPFLAGS_HAVE_VECTORCALL
+#else
+#  define Q_Py_TPFLAGS_HAVE_VECTORCALL _Py_TPFLAGS_HAVE_VECTORCALL
+#endif
+
+#if !Q_HAS_VECTORCALL
+#  define Q_Py_TPFLAGS_METHOD_DESCRIPTOR 0
+#else
+#  define Q_Py_TPFLAGS_METHOD_DESCRIPTOR Py_TPFLAGS_METHOD_DESCRIPTOR
+#endif
+
+#if !Q_HAS_VECTORCALL
+#  define Q_PY_VECTORCALL_ARGUMENTS_OFFSET                                     \
+    ((size_t)1 << (8 * sizeof(size_t) - 1))
+#else
+#  define Q_PY_VECTORCALL_ARGUMENTS_OFFSET PY_VECTORCALL_ARGUMENTS_OFFSET
+#endif
+
+
+Py_ssize_t Q_PyVectorcall_NARGS(size_t n);
+
+PyObject * Q_PyObject_Vectorcall(
+    PyObject * callable, PyObject * const * args, size_t nargsf,
+    PyObject * kwnames);
+PyObject * Q_PyObject_VectorcallDict(
+    PyObject * callable, PyObject * const * args, size_t nargsf,
+    PyObject * kwdict);
+PyObject * Q_PyObject_VectorcallMethod(
+    PyObject * name, PyObject * const * args, size_t nargsf, PyObject * kwdict);
+
+
+#ifdef __cplusplus
+} // extern "C"
+#endif


### PR DESCRIPTION
Vectorcall is a new argument passing convention in CPython that was formalized in [PEP-590](https://www.python.org/dev/peps/pep-0590/), and made fully public in Python 3.9. It has a number of speed advantages over `tp_call` which make it desirable to use in `uarray`. It's also existed in some form since long before 3.9 as CPython's internal "FastCall" convention.

This PR provides shims to make Python 3.9-style Vectorcall available in CPython >= 3.6 and in PyPy as a wrapper around `PyObject_Call`. It also uses `Vectorcall` in places where previously I had to explicitly create a new `PyTuple` object to make the call.

In a simple benchmark, this gives a noticeable speedup on all CPython versions >= 3.7 and is neutral for Python 3.6.

| Python Version | master | vectorcall |
|----------------|--------|------------|
| 3.6            | 390 ns | 390 ns     |
| 3.7            | 275 ns | 115 ns     |
| 3.8            | 280 ns | 115 ns     |
| 3.9            | 230 ns | 103 ns     |

<details>
<summary>Benchmark code</summary>

```python
from timeit import Timer
import uarray as ua

class Backend:
    __ua_domain__ = 'bench'
    def __ua_function__(self, func, args, kwargs):
        return None

mm = ua.generate_multimethod(lambda a: (a,), lambda a, kw, d: (a, kw), 'bench')
ua.register_backend(Backend())

t = Timer('mm(None)', globals=dict(mm=mm))

results = []
n, _ = t.autorange()
n //= 10
for _ in range(10):
    t.timeit(n//10)  # Warm-up run
    results.extend([t.timeit(n) for _ in range(10)])

time = min(results) / n

print(f'{time*1e9:.2f} ns uarray overhead')
```

</details>