### PR TITLE
Fix build warning from vectorcall.h

### DIFF
--- a/uarray/vectorcall.h
+++ b/uarray/vectorcall.h
@@ -6,8 +6,11 @@ extern "C" {
 #endif
 
 // True if python supports vectorcall on custom classes
-#define Q_HAS_VECTORCALL                                                       \
-  (!defined(PYPY_VERSION) && (PY_VERSION_HEX >= 0x03080000))
+#if (!defined(PYPY_VERSION) && (PY_VERSION_HEX >= 0x03080000))
+  #define Q_HAS_VECTORCALL 1
+#else
+  #define Q_HAS_VECTORCALL 0
+#endif
 
 #if !Q_HAS_VECTORCALL
 #  define Q_Py_TPFLAGS_HAVE_VECTORCALL 0

--- a/uarray/vectorcall.h
+++ b/uarray/vectorcall.h
@@ -7,9 +7,9 @@ extern "C" {
 
 // True if python supports vectorcall on custom classes
 #if (!defined(PYPY_VERSION) && (PY_VERSION_HEX >= 0x03080000))
-  #define Q_HAS_VECTORCALL 1
+#  define Q_HAS_VECTORCALL 1
 #else
-  #define Q_HAS_VECTORCALL 0
+#  define Q_HAS_VECTORCALL 0
 #endif
 
 #if !Q_HAS_VECTORCALL


### PR DESCRIPTION
Warning looks like:
```
[9/1557] Compiling C++ object scipy/_lib/_uarray/_uarray.cpython-310-darwin.so.p/vectorcall.cxx.o
warning: unknown warning option '-Wno-terminate' [-Wunknown-warning-option]
In file included from ../scipy/_lib/_uarray/vectorcall.cxx:1:
../scipy/_lib/_uarray/vectorcall.h:12:6: warning: macro expansion producing 'defined' has undefined behavior [-Wexpansion-to-defined]
     ^
../scipy/_lib/_uarray/vectorcall.h:10:5: note: expanded from macro 'Q_HAS_VECTORCALL'
  (!defined(PYPY_VERSION) && (PY_VERSION_HEX >= 0x03080000))
    ^
../scipy/_lib/_uarray/vectorcall.h:20:6: warning: macro expansion producing 'defined' has undefined behavior [-Wexpansion-to-defined]
     ^
../scipy/_lib/_uarray/vectorcall.h:10:5: note: expanded from macro 'Q_HAS_VECTORCALL'
  (!defined(PYPY_VERSION) && (PY_VERSION_HEX >= 0x03080000))
    ^
../scipy/_lib/_uarray/vectorcall.h:26:6: warning: macro expansion producing 'defined' has undefined behavior [-Wexpansion-to-defined]
     ^
../scipy/_lib/_uarray/vectorcall.h:10:5: note: expanded from macro 'Q_HAS_VECTORCALL'
  (!defined(PYPY_VERSION) && (PY_VERSION_HEX >= 0x03080000))
    ^
4 warnings generated.
```