### PR TITLE
Remove one ref that lead to deinitialization of BackendNotImplementedError

### DIFF
--- a/uarray/_uarray_dispatch.cxx
+++ b/uarray/_uarray_dispatch.cxx
@@ -1816,7 +1816,6 @@ extern "C" MODULE_EXPORT PyObject * PyInit__uarray(void) {
       PyExc_NotImplementedError, nullptr));
   if (!BackendNotImplementedError)
     return nullptr;
-  Py_INCREF(BackendNotImplementedError.get());
   PyModule_AddObject(
       m.get(), "BackendNotImplementedError", BackendNotImplementedError.get());
 

--- a/uarray/tests/test_uarray.py
+++ b/uarray/tests/test_uarray.py
@@ -1,5 +1,7 @@
 import uarray as ua
 import pickle
+import subprocess
+import sys
 
 import pytest  # type: ignore
 
@@ -578,3 +580,13 @@ def test_default(nullary_mm):
     with ua.set_backend(be, coerce=True), pytest.raises(ua.BackendNotImplementedError):
         mm2()
     assert num_calls[0] == 1
+
+
+def test_refcnt():
+    out, _ = subprocess.Popen([sys.executable, "-c", """
+import uarray
+import sys
+print (sys.getrefcount(uarray._uarray.BackendNotImplementedError))
+"""], stdout=subprocess.PIPE, shell=False).communicate()
+    assert int(out.decode()) == 7
+


### PR DESCRIPTION
Remove one ref that lead to deinitialization of BackendNotImplementedError after a Py_FinalizeEx that leads to segmentation faults.

