### PR TITLE
ENH: Add annotations for the `uarray._uarray` extension module

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           name: Wheels
           path: ./wheelhouse/*.whl
-  
+
   doc_lint_cov:
     name: Documentation, Linting and Coverage
     runs-on: ubuntu-latest
@@ -65,6 +65,9 @@ jobs:
       - name: Code style and tests
         run: |
           pytest --pyargs uarray
+      - name: mypy
+        run: |
+          mypy uarray
       - name: Run clang-format style check for C/C++ code.
         uses: jidicula/clang-format-action@v4.3.1
         with:
@@ -77,7 +80,7 @@ jobs:
           env_vars: OS,PYTHON
           fail_ci_if_error: false
           verbose: true
-  
+
   pypy3:
     name: Tests for PyPy3
     runs-on: ubuntu-latest
@@ -93,7 +96,7 @@ jobs:
       - name: Run tests
         run: |
           pytest --pyargs uarray
-  
+
   scipy_fft:
     name: Run SciPy FFT tests
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ sandbox.py
 build/
 default.profraw
 uarray/_version.py
+*.pyd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,12 @@ exclude = 'uarray/_version.py'
 
 [tool.setuptools_scm]
 write_to = "uarray/_version.py"
+
+[tool.mypy]
+show_error_codes = true
+
+[[tool.mypy.overrides]]
+module = [
+    "pytest_black.*",
+]
+ignore_missing_imports = true

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -2,3 +2,4 @@ pytest>=3.5
 pytest-flake8
 pytest-cov
 pytest-black; platform_python_implementation == 'CPython'
+mypy>=0.930

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ setup(
         "Intended Audience :: Developers",
         "Intended Audience :: Science/Research",
     ],
+    package_data={"uarray": ["*.pyi"]},
     project_urls={
         "Documentation": "https://uarray.org/",
         "Source": "https://github.com/Quansight-Labs/uarray/",

--- a/uarray/_backend.py
+++ b/uarray/_backend.py
@@ -96,10 +96,13 @@ def pickle_skip_backend_context(ctx):
     return _SkipBackendContext, ctx._pickle()
 
 
-copyreg.pickle(_Function, pickle_function)
-copyreg.pickle(_uarray._BackendState, pickle_state)
-copyreg.pickle(_SetBackendContext, pickle_set_backend_context)
-copyreg.pickle(_SkipBackendContext, pickle_skip_backend_context)
+# TODO: Remove the `if` block once python/typeshed#7415
+# has been integrated into mypy
+if not typing.TYPE_CHECKING:
+    copyreg.pickle(_Function, a)
+    copyreg.pickle(_uarray._BackendState, pickle_state)
+    copyreg.pickle(_SetBackendContext, pickle_set_backend_context)
+    copyreg.pickle(_SkipBackendContext, pickle_skip_backend_context)
 
 
 def get_state():

--- a/uarray/_backend.py
+++ b/uarray/_backend.py
@@ -12,7 +12,7 @@ ArgumentReplacerType = typing.Callable[
     [typing.Tuple, typing.Dict, typing.Tuple], typing.Tuple[typing.Tuple, typing.Dict]
 ]
 
-from ._uarray import (  # type: ignore
+from ._uarray import (
     BackendNotImplementedError,
     _Function,
     _SkipBackendContext,

--- a/uarray/_backend.py
+++ b/uarray/_backend.py
@@ -99,7 +99,7 @@ def pickle_skip_backend_context(ctx):
 # TODO: Remove the `if` block once python/typeshed#7415
 # has been integrated into mypy
 if not typing.TYPE_CHECKING:
-    copyreg.pickle(_Function, a)
+    copyreg.pickle(_Function, pickle_function)
     copyreg.pickle(_uarray._BackendState, pickle_state)
     copyreg.pickle(_SetBackendContext, pickle_set_backend_context)
     copyreg.pickle(_SkipBackendContext, pickle_skip_backend_context)

--- a/uarray/_typing.pyi
+++ b/uarray/_typing.pyi
@@ -1,0 +1,54 @@
+"""Helper module with various typing-related utilities."""
+
+from collections.abc import Callable
+from typing import Any, Protocol, TypeVar, Iterable, type_check_only
+
+import uarray
+
+_T = TypeVar("_T")
+_T_co = TypeVar("_T_co", covariant=True)
+
+@type_check_only
+class _PySequence(Protocol[_T_co]):
+    def __len__(self) -> int: ...
+    def __getitem__(self, key: int, /) -> _T_co: ...
+
+@type_check_only
+class _SupportsUADomain(Protocol):
+    @property
+    def __ua_domain__(self) -> str | _PySequence[str]: ...
+
+@type_check_only
+class _SupportsUAConvert(Protocol):
+    def __ua_convert__(
+        self,
+        dispatchables: tuple[uarray.Dispatchable, ...],
+        coerce: bool,
+        /,
+    ) -> Iterable[Any]: ...
+
+_ReplacerFunc = Callable[
+    [
+        tuple[Any, ...],
+        dict[str, Any],
+        tuple[uarray.Dispatchable, ...],
+    ],
+    tuple[tuple[Any, ...], dict[str, Any]],
+]
+
+_PyGlobalDict = dict[
+    str,
+    tuple[
+        tuple[_T | None, bool, bool],
+        list[_T],
+        bool,
+    ],
+]
+
+_PyLocalDict = dict[
+    str,
+    tuple[
+        list[_T],
+        list[tuple[_T, bool, bool]],
+    ],
+]

--- a/uarray/_uarray.pyi
+++ b/uarray/_uarray.pyi
@@ -2,7 +2,7 @@
 
 import types
 from collections.abc import Callable, Iterable
-from typing import Any, final, overload, Generic, TypeVar
+from typing import Any, final, overload, Generic
 
 # TODO: Import from `typing` once `uarray` requires Python >= 3.10
 from typing_extensions import ParamSpec
@@ -17,7 +17,6 @@ from uarray._typing import (
 )
 
 _P = ParamSpec("_P")
-_ReturnT = TypeVar("_ReturnT", bound=tuple[uarray.Dispatchable, ...])
 
 class BackendNotImplementedError(NotImplementedError): ...
 
@@ -74,10 +73,10 @@ class _BackendState:
 
 # TODO: Remove the `type: ignore` once python/mypy#12033 has been bug fixed
 @final  # type: ignore[arg-type]
-class _Function(Generic[_P, _ReturnT]):
+class _Function(Generic[_P]):
     def __init__(
         self,
-        extractor: Callable[_P, _ReturnT],
+        extractor: Callable[_P, tuple[uarray.Dispatchable, ...]],
         replacer: None | _ReplacerFunc,
         domain: str,
         def_args: tuple[Any, ...],
@@ -85,7 +84,7 @@ class _Function(Generic[_P, _ReturnT]):
         def_impl: None | Callable[..., Any],
     ) -> None: ...
     def __repr__(self) -> str: ...
-    def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _ReturnT: ...
+    def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> Any: ...
     @overload
     def __get__(self, obj: None, type: type[Any]) -> _Function: ...
     @overload
@@ -93,7 +92,7 @@ class _Function(Generic[_P, _ReturnT]):
         self, obj: object, type: None | type[Any] = ...
     ) -> types.MethodType: ...
     @property
-    def arg_extractor(self) -> Callable[_P, _ReturnT]: ...
+    def arg_extractor(self) -> Callable[_P, tuple[uarray.Dispatchable, ...]]: ...
     @property
     def arg_replacer(self) -> None | _ReplacerFunc: ...
     @property
@@ -106,7 +105,7 @@ class _Function(Generic[_P, _ReturnT]):
     __name__: str
     __qualname__: str
     __doc__: None | str
-    __wrapped__: Callable[_P, _ReturnT]
+    __wrapped__: Callable[_P, tuple[uarray.Dispatchable, ...]]
     __annotations__: dict[str, Any]
 
 def set_global_backend(

--- a/uarray/_uarray.pyi
+++ b/uarray/_uarray.pyi
@@ -1,0 +1,126 @@
+"""Annotations for the ``uarray._uarray`` extension module."""
+
+import types
+from collections.abc import Callable, Iterable
+from typing import Any, final, overload
+
+import uarray
+from uarray._typing import (
+    _PyGlobalDict,
+    _PyLocalDict,
+    _ReplacerFunc,
+    _SupportsUAConvert,
+    _SupportsUADomain,
+)
+
+class BackendNotImplementedError(NotImplementedError): ...
+
+@final
+class _SkipBackendContext:
+    def __init__(self, backend: _SupportsUADomain) -> None: ...
+    def __enter__(self) -> None: ...
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: types.TracebackType | None,
+        /,
+    ) -> None: ...
+    def _pickle(self) -> tuple[_SupportsUADomain]: ...
+
+@final
+class _SetBackendContext:
+    def __init__(
+        self,
+        backend: _SupportsUADomain,
+        coerce: bool = ...,
+        only: bool = ...,
+    ) -> None: ...
+    def __enter__(self) -> None: ...
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: types.TracebackType | None,
+        /,
+    ) -> None: ...
+    def _pickle(self) -> tuple[_SupportsUADomain, bool, bool]: ...
+
+# NOTE: Parametrize w.r.t. `__ua_domain__` when returning, but use `Any`
+# when used as argument type. Due to lists being invariant the `__ua_domain__`
+# protocol will likelly be disruptivelly strict in the latter case, hence the
+# usage of `Any` as an escape hatch.
+@final
+class _BackendState:
+    def _pickle(self) -> tuple[
+        _PyGlobalDict[_SupportsUADomain],
+        _PyLocalDict[_SupportsUADomain],
+        bool,
+    ]: ...
+    @classmethod
+    def _unpickle(
+        cls,
+        py_global: _PyGlobalDict[Any],
+        py_locals: _PyLocalDict[Any],
+        use_thread_local_globals: bool,
+        /,
+    ) -> _BackendState: ...
+
+@final
+class _Function:
+    def __init__(
+        self,
+        extractor: Callable[..., tuple[uarray.Dispatchable, ...]],
+        replacer: None | _ReplacerFunc,
+        domain: str,
+        def_args: tuple[Any, ...],
+        def_kwargs: dict[str, Any],
+        def_impl: None | Callable[..., Any],
+    ) -> None: ...
+    def __repr__(self) -> str: ...
+    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
+    @overload
+    def __get__(self, obj: None, type: type[Any]) -> _Function: ...
+    @overload
+    def __get__(
+        self, obj: object, type: None | type[Any] = ...
+    ) -> types.MethodType: ...
+    @property
+    def arg_extractor(self) -> Callable[..., tuple[uarray.Dispatchable, ...]]: ...
+    @property
+    def arg_replacer(self) -> None | _ReplacerFunc: ...
+    @property
+    def default(self) -> None | Callable[..., Any]: ...
+    @property
+    def domain(self) -> str: ...
+    # NOTE: These attributes are dynamically inserted by
+    # `uarray.generate_multimethod` via a `functools.update_wrapper` call
+    __module__: str
+    __name__: str
+    __qualname__: str
+    __doc__: None | str
+    __wrapped__: Callable[..., tuple[uarray.Dispatchable, ...]]
+    __annotations__: dict[str, Any]
+
+def set_global_backend(
+    backend: _SupportsUADomain,
+    coerce: bool = ...,
+    only: bool = ...,
+    try_last: bool = ...,
+    /,
+) -> None: ...
+def clear_backends(
+    domain: None | str,
+    registered: bool = ...,
+    global_: bool = ...,
+    /,
+) -> None: ...
+def determine_backend(
+    domain_object: str,
+    dispatchables: Iterable[uarray.Dispatchable],
+    coerce: bool,
+    /,
+) -> _SupportsUAConvert: ...
+def register_backend(backend: _SupportsUADomain, /) -> None: ...
+def get_state() -> _BackendState: ...
+def set_state(arg: _BackendState, reset_allowed: bool = ..., /) -> None: ...


### PR DESCRIPTION
Recently I noticed in scipy that uarray is still lacking type annotations, so if there is any interest I would very much like to contribute them.

This PR in particular focuses on the `uarray._uarray` extension module. As the latter is written in C++, it is necessary to resort to .pyi stub files for distributing PEP 484 type annotations.