### PR TITLE
Proof of concept: annotation-based argument extractor/replacer

### DIFF
--- a/uarray/tests/test_typing.py
+++ b/uarray/tests/test_typing.py
@@ -1,0 +1,56 @@
+import uarray
+from uarray.typing import _generate_arg_extractor_replacer
+from typing import Optional
+
+def example_function(a: uarray.typing.Dispatchable[int, 'int', True],
+                     b: uarray.typing.Dispatchable[float, 'float', False],
+                     c: Optional[str] = None):
+    pass
+
+
+def test_automatic_extractor():
+    extractor, _ = _generate_arg_extractor_replacer(example_function)
+
+    def validate_dispatchables(dispatchables, a, b):
+        assert isinstance(dispatchables, tuple)
+        assert len(dispatchables) == 2
+        assert dispatchables[0].value is a
+        assert dispatchables[0].type == 'int'
+        assert dispatchables[0].coercible == True
+
+        assert dispatchables[1].value is b
+        assert dispatchables[1].type == 'float'
+        assert dispatchables[1].coercible == False
+
+    a, b = 1, 2.0
+    validate_dispatchables(extractor(a, b), a, b)
+    validate_dispatchables(extractor(a, b=b), a, b)
+    validate_dispatchables(extractor(b=b, a=a), a, b)
+    validate_dispatchables(extractor(c='c', a=a, b=b), a, b)
+    validate_dispatchables(extractor(a, b, 'c'), a, b)
+
+def test_automatic_replacer():
+    _, replacer = _generate_arg_extractor_replacer(example_function)
+
+    a, b = 1, 2.0
+    d = (3, 4.0)
+
+    args, kwargs = replacer((a, b), {}, d)
+    assert args == (3, 4.0)
+    assert kwargs == {}
+
+    args, kwargs = replacer((a,), dict(b=b), d)
+    assert args == (3,)
+    assert kwargs == dict(b=4.0)
+
+    args, kwargs = replacer((), dict(a=a, b=b), d)
+    assert args == ()
+    assert kwargs == dict(a=3, b=4.0)
+
+    args, kwargs = replacer((a, b, 'c'), dict(), d)
+    assert args == (3, 4.0, 'c')
+    assert kwargs == dict()
+
+    args, kwargs = replacer((a, b), dict(c='c'), d)
+    assert args == (3, 4.0)
+    assert kwargs == dict(c='c')

--- a/uarray/tests/test_typing.py
+++ b/uarray/tests/test_typing.py
@@ -1,36 +1,46 @@
 import uarray
-from uarray.typing import _generate_arg_extractor_replacer
+from uarray.typing import _generate_arg_extractor_replacer, DispatchableArg
 from typing import Optional
 
-def example_function(a: uarray.typing.Dispatchable[int, 'int', True],
-                     b: uarray.typing.Dispatchable[float, 'float', False],
-                     c: Optional[str] = None):
+
+def example_function(a: int, b: float, c: Optional[str] = None):
     pass
 
 
+EXAMPLE_ANNOTATIONS = (
+    DispatchableArg("a", dispatch_type="int", coercible=True),
+    DispatchableArg("b", dispatch_type="float", coercible=False),
+)
+
+
 def test_automatic_extractor():
-    extractor, _ = _generate_arg_extractor_replacer(example_function)
+    extractor, _ = _generate_arg_extractor_replacer(
+        example_function, EXAMPLE_ANNOTATIONS
+    )
 
     def validate_dispatchables(dispatchables, a, b):
         assert isinstance(dispatchables, tuple)
         assert len(dispatchables) == 2
         assert dispatchables[0].value is a
-        assert dispatchables[0].type == 'int'
+        assert dispatchables[0].type == "int"
         assert dispatchables[0].coercible == True
 
         assert dispatchables[1].value is b
-        assert dispatchables[1].type == 'float'
+        assert dispatchables[1].type == "float"
         assert dispatchables[1].coercible == False
 
     a, b = 1, 2.0
     validate_dispatchables(extractor(a, b), a, b)
     validate_dispatchables(extractor(a, b=b), a, b)
     validate_dispatchables(extractor(b=b, a=a), a, b)
-    validate_dispatchables(extractor(c='c', a=a, b=b), a, b)
-    validate_dispatchables(extractor(a, b, 'c'), a, b)
+    validate_dispatchables(extractor(c="c", a=a, b=b), a, b)
+    validate_dispatchables(extractor(a, b, "c"), a, b)
+
 
 def test_automatic_replacer():
-    _, replacer = _generate_arg_extractor_replacer(example_function)
+    _, replacer = _generate_arg_extractor_replacer(
+        example_function, EXAMPLE_ANNOTATIONS
+    )
 
     a, b = 1, 2.0
     d = (3, 4.0)
@@ -47,10 +57,10 @@ def test_automatic_replacer():
     assert args == ()
     assert kwargs == dict(a=3, b=4.0)
 
-    args, kwargs = replacer((a, b, 'c'), dict(), d)
-    assert args == (3, 4.0, 'c')
+    args, kwargs = replacer((a, b, "c"), dict(), d)
+    assert args == (3, 4.0, "c")
     assert kwargs == dict()
 
-    args, kwargs = replacer((a, b), dict(c='c'), d)
+    args, kwargs = replacer((a, b), dict(c="c"), d)
     assert args == (3, 4.0)
-    assert kwargs == dict(c='c')
+    assert kwargs == dict(c="c")

--- a/uarray/typing.py
+++ b/uarray/typing.py
@@ -1,0 +1,92 @@
+from typing import Any, Annotated, Callable
+import typing
+import inspect
+from dataclasses import dataclass
+import functools
+
+import uarray
+
+
+@dataclass(frozen=True)
+class _DispatchableAnnotation:
+    dispatch_type: Any
+    coercible: bool = True
+
+
+class Dispatchable:
+    def __new__(cls, *args, **kwargs):
+        raise TypeError("uarray.typing.Dispatchable cannot be instantiated")
+
+    def __class_getitem__(cls, params):
+        if not isinstance(params, tuple) or len(params) < 2:
+            raise TypeError(
+                "uarray.typing.Dispatchable[...] expects two or more arguments "
+                "(type and and dispatch_type).")
+        T = params[0]
+        tail = params[1:]
+
+        return Annotated[T, _DispatchableAnnotation(*tail)]
+
+
+def _generate_arg_extractor_replacer(func: Callable):
+    sig = inspect.signature(func)
+    dispatchable_args = []
+    dispatchable_kwargs = []
+
+    for i, p in enumerate(sig.parameters.values()):
+        if typing.get_origin(p.annotation) is not Annotated:
+            continue
+        dispatch_annotations = [a for a in typing.get_args(p.annotation)
+                                if isinstance(a, _DispatchableAnnotation)]
+        if len(dispatch_annotations) == 0:
+            continue
+        if len(dispatch_annotations) > 1:
+            raise TypeError("Expected at most one Dispatchable annotation")
+
+        ann = dispatch_annotations[0]
+
+        if p.kind in (inspect.Parameter.POSITIONAL_ONLY,
+                      inspect.Parameter.POSITIONAL_OR_KEYWORD):
+            dispatchable_args.append((i, ann))
+
+        if p.kind in (inspect.Parameter.KEYWORD_ONLY,
+                      inspect.Parameter.POSITIONAL_OR_KEYWORD):
+            dispatchable_kwargs.append((p.name, ann))
+
+    @functools.wraps(func)
+    def arg_extractor(*args, **kwargs):
+        # Raise appropriate TypeError if the signature doesn't match
+        func(*args, **kwargs)
+
+        dispatchables = []
+        for i, ann in dispatchable_args:
+            if len(args) > i:
+                dispatchables.append(uarray.Dispatchable(
+                    args[i], ann.dispatch_type, ann.coercible))
+
+        for name, ann in dispatchable_kwargs:
+            if name in kwargs:
+                dispatchables.append(uarray.Dispatchable(
+                    kwargs[name], ann.dispatch_type, ann.coercible))
+
+        return tuple(dispatchables)
+
+
+    def arg_replacer(args, kwargs, dispatchables):
+        new_args = list(args)
+        new_kwargs = kwargs.copy()
+        cur_idx = 0
+
+        for i, ann in dispatchable_args:
+            if len(args) > i:
+                new_args[i] = dispatchables[cur_idx]
+                cur_idx += 1
+
+        for name, ann in dispatchable_kwargs:
+            if name in kwargs:
+                new_kwargs[name] = dispatchables[cur_idx]
+                cur_idx += 1
+        assert cur_idx == len(dispatchables)
+        return tuple(new_args), new_kwargs
+
+    return arg_extractor, arg_replacer


### PR DESCRIPTION
This explores the posibility of automatically generating the argument extractor and replacer based on inline type annotations (for simple cases). So, for example `scipy.fft.fft` might look like:

```python
@_dispatch
def fft(x: ua.typing.Dispatchable[ArrayLike, np.ndarray], n=None, axis=-1,
        norm=None, overwrite_x=False, workers=None, *, plan=None):
    pass
```

The signature is inspected ahead-of-time so as to minimize call overhead but a Python implementation is still too slow. ~400 ns for
even a simple `f(x)` signature. However, if it were lowered to C++ then the concept may still be viable.

This also relies on `typing.Annotated` to specify `dispatch_type` and `coercible` but `typing.Annotated` itself requires Python 3.9. It may be possible to emulate on earlier python versions, otherwise I think the dispatch metadata would need to go elsewhere. Perhaps something like:

```python
@_dispatch([ua.DispatchableArg(name='x', dispatch_type=np.ndarray, coercible=True)])
def fft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *, plan=None):
    pass
```

cc @thomasjpfan 