### PR TITLE
MAINT: fix small typo in `small_dynamic_array.h`

### DIFF
--- a/uarray/small_dynamic_array.h
+++ b/uarray/small_dynamic_array.h
@@ -142,7 +142,7 @@ public:
 
     clear();
 
-    size_ = copy.size;
+    size_ = copy.size_;
     try {
       allocate();
     } catch (...) {


### PR DESCRIPTION
on clang-19, this causes:
```
../scipy/_lib/_uarray/small_dynamic_array.h(145,18): error: reference to non-static member function must be called
  145 |     size_ = copy.size;
      |             ~~~~~^~~~
1 error generated.
```

cc @h-vetinari, x-ref https://github.com/scipy/scipy/pull/21069