### PR TITLE
DOC: Fix rst syntax

### DIFF
--- a/src/uarray/__init__.py
+++ b/src/uarray/__init__.py
@@ -1,5 +1,6 @@
 """
-.. note:
+.. note::
+
     If you are looking for overrides for NumPy-specific methods, see the
     documentation for :obj:`unumpy`. This page explains how to write
     back-ends and multimethods.


### PR DESCRIPTION
Directive have 2 colons, (and usually a blank line)